### PR TITLE
en vista superadmin, se modificó el boton finalizar día

### DIFF
--- a/frontend/src/hooks/useDiaFinalizado.js
+++ b/frontend/src/hooks/useDiaFinalizado.js
@@ -1,0 +1,45 @@
+// Hook personalizado para manejar el estado de "diaFinalizado" sincronizado con localStorage
+import { useState, useEffect } from 'react';
+
+export const useDiaFinalizado = () => {
+  const [diaFinalizado, setDiaFinalizadoState] = useState(
+    localStorage.getItem("diaFinalizado") === "true"
+  );
+
+  useEffect(() => {
+    // Función para actualizar el estado desde localStorage
+    const updateStateFromStorage = () => {
+      const value = localStorage.getItem("diaFinalizado") === "true";
+      setDiaFinalizadoState(value);
+    };
+
+    // Escuchar cambios en localStorage de otras pestañas
+    const handleStorageChange = (e) => {
+      if (e.key === "diaFinalizado") {
+        setDiaFinalizadoState(e.newValue === "true");
+      }
+    };
+
+    // Escuchar cambios dentro de la misma pestaña cada segundo
+    const interval = setInterval(updateStateFromStorage, 1000);
+
+    // Agregar event listeners
+    window.addEventListener('storage', handleStorageChange);
+
+    // Limpieza
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      clearInterval(interval);
+    };
+  }, []);
+
+  // Función para setear el valor que también actualiza localStorage
+  const setDiaFinalizado = (value) => {
+    localStorage.setItem("diaFinalizado", value.toString());
+    setDiaFinalizadoState(value);
+    // Disparar evento manualmente para notificar a otros componentes
+    window.dispatchEvent(new Event('storage'));
+  };
+
+  return [diaFinalizado, setDiaFinalizado];
+};

--- a/frontend/src/pages/dashboard.jsx
+++ b/frontend/src/pages/dashboard.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Wrench, Calendar, Clock, PlayCircle, CheckCircle, Flag, Zap, AlertTriangle } from '../iconos';
 import CurrentTurnCard from '../components/CurrentTurnCard';
 import QueueItem from '../components/QueueItem';
+import { useDiaFinalizado } from '../hooks/useDiaFinalizado';
 import './pages-styles/dashboard.css';
 import { motion, AnimatePresence } from "framer-motion";
 
@@ -12,6 +13,8 @@ const Dashboard = () => {
   const [fila, setFila] = useState([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState("");
+
+  const [diaFinalizado] = useDiaFinalizado();
 
   // Cargar la fila desde la API
   useEffect(() => {
@@ -65,6 +68,7 @@ const Dashboard = () => {
                         <button
                           className="btn btn-primary w-100"
                           onClick={() => navigate('/formulario_turno')}
+                          disabled={diaFinalizado}
                         >
                           Agendar Ahora
                         </button>

--- a/frontend/src/pages/vista_superadministrador.jsx
+++ b/frontend/src/pages/vista_superadministrador.jsx
@@ -5,6 +5,7 @@ import { Zap, ArrowLeft } from "../iconos";
 import { List, Grid } from "lucide-react";
 import WorkerTurnCard from "../components/WorkerTurnCard"; 
 import StatusBadge from "../components/StatusBadge";
+import { useDiaFinalizado } from "../hooks/useDiaFinalizado";
 import "./pages-styles/superadmin.css";
 
 const VistaSuperadministrador = () => {
@@ -15,6 +16,8 @@ const VistaSuperadministrador = () => {
   const [nombreEmpleado, setNombreEmpleado] = useState("");
   const [vistaLista, setVistaLista] = useState(false);
   const [busqueda, setBusqueda] = useState("");
+  const [showModal, setShowModal] = useState(false);
+  const [diaFinalizado, setDiaFinalizado] = useDiaFinalizado();
 
   useEffect(() => {
     const empleado = JSON.parse(localStorage.getItem("empleado"));
@@ -32,9 +35,23 @@ const VistaSuperadministrador = () => {
   }, [navigate]);
 
 
-  const finalizarDia = () => {
-    alert("Día finalizado, se limpiaron los turnos.");
-    setHistorial([]);
+  const toggleDia = () => {
+    if (diaFinalizado) {
+      // Iniciar nuevo día usando el mismo botón
+      setDiaFinalizado(false);
+      alert("Se inició un nuevo día. Ahora se pueden agendar turnos.");
+    } else {
+      // Finalizar día
+      setShowModal(true);
+    }
+  };
+
+  //función para finalizar el día
+  const confirmarFinalizar = () => {
+    setDiaFinalizado(true);
+    //setHistorial([]);
+    setShowModal(false);
+    alert("Día finalizado");
   };
 
   return (
@@ -84,11 +101,16 @@ const VistaSuperadministrador = () => {
 
               </div>
 
+              {/* Botón para finalizar el día */}
               <div className="text-center mt-3 mb-5">
-                <button className="btn btn-custom" onClick={finalizarDia}>
-                  Finalizar Día
+                <button
+                  className={`btn ${diaFinalizado ? "btn-success" : "btn-danger"}`}
+                  onClick={toggleDia}
+                >
+                  {diaFinalizado ? "Iniciar Nuevo Día" : "Finalizar Día"}
                 </button>
-                <button className="btn btn-custom" onClick={() => navigate("/historial")}>
+
+                <button className="btn btn-custom ms-2" onClick={() => navigate("/historial")}>
                   Historial
                 </button>
               </div>
@@ -96,6 +118,31 @@ const VistaSuperadministrador = () => {
           </div>
         </div>
       </div>
+
+      {/* Modal de confirmación */}
+      {showModal && !diaFinalizado && (
+        <div className="modal fade show d-block" style={{ backgroundColor: "rgba(0,0,0,0.5)" }}>
+          <div className="modal-dialog modal-dialog-centered">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Confirmar acción</h5>
+                <button type="button" className="btn-close" onClick={() => setShowModal(false)} />
+              </div>
+              <div className="modal-body">
+                <p>¿Seguro que deseas finalizar el día? </p>
+              </div>
+              <div className="modal-footer">
+                <button className="btn btn-secondary" onClick={() => setShowModal(false)}>
+                  Cancelar
+                </button>
+                <button className="btn btn-danger" onClick={confirmarFinalizar}>
+                  Confirmar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Al presionar finalizar día en superadministrador, sale un modal de confirmación, después, se actualiza el botón a "Iniciar nuevo día" y  en ese mismo instante en el dashboard se deshabilita el botón agendar turno.