### PR TITLE
creacion del apartado administrar empleados

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,7 @@ import Historial from './pages/historial';
 import { EmpleadoProvider } from "./layouts/EmpleadoContext";
 import RegisterGerentes from './pages/register_gerentes_y_trabajadores';
 import RegisterTrabajadores from './pages/register_trabajadores';
+import AdministrarEmpleados from "./pages/administrar_empleados";
 
 // Layout condicional
 const AppLayout = ({ children }) => {
@@ -63,6 +64,7 @@ const PitLineApp = () => {
             <Route path="/historial" element={<Historial />} />
             <Route path="/register_gerentes_y_trabajadores" element={<RegisterGerentes />} />
             <Route path="/register_trabajadores" element={<RegisterTrabajadores />} />
+            <Route path="/administrar" element={<AdministrarEmpleados />} />
           </Routes>
         </AppLayout>
       </Router>

--- a/frontend/src/pages/administrar_empleados.jsx
+++ b/frontend/src/pages/administrar_empleados.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Edit, Trash2 } from "../iconos";
+import "./pages-styles/administrar_empleados.css";
+
+export default function AdministrarEmpleados() {
+  const [empleados, setEmpleados] = useState([]);
+
+  useEffect(() => {
+    // Aquí conectamos con el backend real
+
+    // Por ahora, datos de prueba
+    setEmpleados([
+      { id: 1, nombre: "JUAN PEREZ", cargo: "COTIZACIÓN" },
+      { id: 2, nombre: "ANA LÓPEZ", cargo: "COTIZACIÓN" },
+      { id: 3, nombre: "CARLOS RAMOS", cargo: "COTIZACIÓN" },
+      { id: 4, nombre: "LUCÍA MEJÍA", cargo: "REPARACIÓN" },
+      { id: 5, nombre: "JORGE SOTO", cargo: "COTIZACIÓN" },
+      { id: 6, nombre: "MARÍA NAVA", cargo: "REPARACIÓN" },
+      { id: 7, nombre: "RAÚL REYES", cargo: "COTIZACIÓN" },
+      { id: 8, nombre: "KARLA MENA", cargo: "REPARACIÓN" },
+      { id: 9, nombre: "MARIO DÍAZ", cargo: "COTIZACIÓN" },
+    ]);
+  }, []);
+
+  const handleDelete = (emp) => {
+    if (confirm(`¿Eliminar a ${emp.nombre}?`)) {
+      setEmpleados((prev) => prev.filter((e) => e.id !== emp.id));
+    }
+  };
+
+  const handleEdit = (emp) => {
+    alert(`Editar a ${emp.nombre}`);
+  };
+
+  return (
+    <div className="container py-5 administrar-page">
+      <h2 className="text-center administrar-title">Administración de gerentes</h2>
+
+      <div className="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
+        {empleados.map((emp) => (
+          <div className="col" key={emp.id}>
+            <div className="card empleado-card">
+              <div className="card-body d-flex justify-content-between align-items-center">
+                <div>
+                  <div className="fw-bold">{emp.nombre}</div>
+                  <div className="text-muted small">{emp.cargo}</div>
+                </div>
+                <div className="d-flex gap-2">
+                  <button
+                    className="btn btn-light btn-sm icon-btn"
+                    onClick={() => handleEdit(emp)}
+                  >
+                    <Edit size={18} />
+                  </button>
+                  <button
+                    className="btn btn-light btn-sm icon-btn"
+                    onClick={() => handleDelete(emp)}
+                  >
+                    <Trash2 size={18} />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="text-center mt-4">
+        <Link
+          to="/register_gerentes_y_trabajadores"
+          className="btn btn-danger fw-bold px-4 add-btn"
+        >
+          Agregar Trabajador +
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/pages-styles/administrar_empleados.css
+++ b/frontend/src/pages/pages-styles/administrar_empleados.css
@@ -1,0 +1,46 @@
+/* Contenedor principal */
+.administrar-page {
+  margin-top: 4rem;
+  padding-bottom: 3rem;
+}
+
+/* Título */
+.administrar-title {
+  font-size: 3rem;
+  font-weight: 700;
+  margin-bottom: 2rem;
+  color: #fff;
+  text-transform: uppercase;
+}
+
+/* Card de empleado */
+.empleado-card {
+  border-radius: 12px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  background: #f9f9f9dc;
+}
+
+.empleado-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+}
+
+/* Botones de acción (editar / eliminar) */
+.icon-btn {
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+}
+
+.icon-btn:hover {
+  background: #f0f0f0;
+}
+
+/* Botón agregar */
+.add-btn {
+  border-radius: 8px;
+  padding: 0.6rem 1.5rem;
+}


### PR DESCRIPTION
Lo que hice fue crear la nueva sección de Administración de empleados. Para esto generé un archivo específico donde se muestra un listado de empleados en forma de tarjetas; por ahora es solo una simulación para comprobar que funcionara. Cada tarjeta incluye el nombre y el cargo del trabajador, y también agregué los botones de editar y eliminar.

Además, incorporé el botón de “Agregar trabajador +”, el cual por ahora está enlazado con la ruta /register_gerentes_y_trabajadores para probar su funcionamiento. Más adelante validaré o añadiré la opción de que, si es superadministrador, se muestren tanto gerentes como empleados, y si es solo gerente se muestren únicamente los empleados. Con esto ya tengo implementada la interfaz principal de administración de empleados, mostrando la información con un diseño consistente al resto del sistema.