### PR TITLE
Modificacion de administrar empleados y creacion de botones faltantes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,6 +23,7 @@ import { EmpleadoProvider } from "./layouts/EmpleadoContext";
 import RegisterGerentes from './pages/register_gerentes_y_trabajadores';
 import RegisterTrabajadores from './pages/register_trabajadores';
 import AdministrarEmpleados from "./pages/administrar_empleados";
+import RequireRoleLocal from "./pages/RequireRoleLocal";
 
 // Layout condicional
 const AppLayout = ({ children }) => {
@@ -64,7 +65,8 @@ const PitLineApp = () => {
             <Route path="/historial" element={<Historial />} />
             <Route path="/register_gerentes_y_trabajadores" element={<RegisterGerentes />} />
             <Route path="/register_trabajadores" element={<RegisterTrabajadores />} />
-            <Route path="/administrar" element={<AdministrarEmpleados />} />
+            <Route path="/administrar_empleados" element={<AdministrarEmpleados />} />
+            <Route path="/administrar_empleados" element={<RequireRoleLocal roles={['superadmin', 'gerente']}><AdministrarEmpleados /></RequireRoleLocal>}/>
           </Routes>
         </AppLayout>
       </Router>

--- a/frontend/src/hooks/auth.js
+++ b/frontend/src/hooks/auth.js
@@ -1,0 +1,38 @@
+// Lee el objeto "empleado" que ustedes ya guardan en localStorage
+// y deduce el rol intentando varios campos/nombres comunes.
+
+export function getCurrentUser() {
+  try {
+    return JSON.parse(localStorage.getItem("empleado")) || null;
+  } catch {
+    return null;
+  }
+}
+
+export function getCurrentUserRole() {
+  const u = getCurrentUser();
+  if (!u) return null;
+
+  const candidates = [
+    u.ROL,
+    u.role,
+    u.rol,
+    u.CARGO,   
+    u.cargo,
+    u.perfil,
+  ]
+    .filter(Boolean)
+    .map((x) => String(x).toLowerCase());
+
+  if (candidates.some((v) => ["superadmin", "super", "root", "general"].includes(v))) {
+    return "superadmin";
+  }
+  if (candidates.some((v) => ["gerente", "manager"].includes(v))) {
+    return "gerente";
+  }
+  // Si en gerente se usa el cargo del área como "reparacion"/"cotizacion", mapea a gerente
+  if (candidates.some((v) => ["reparacion", "cotizacion"].includes(v))) {
+    return "gerente";
+  }
+  return "empleado";
+}

--- a/frontend/src/pages/RequireRoleLocal.jsx
+++ b/frontend/src/pages/RequireRoleLocal.jsx
@@ -1,0 +1,19 @@
+// src/components/RequireRoleLocal.jsx
+import { Navigate } from "react-router-dom";
+import { getCurrentUserRole } from "../hooks/auth";
+
+export default function RequireRoleLocal({ roles = [], children }) {
+  const role = getCurrentUserRole();
+
+  // No logueado
+  if (!role) return <Navigate to="/login" replace />;
+
+  // Sin restricción -> pasa
+  if (!roles.length) return children;
+
+  // Restringido
+  const allowed = roles.includes(role);
+  if (!allowed) return <Navigate to="/" replace />;
+
+  return children;
+}

--- a/frontend/src/pages/administrar_empleados.jsx
+++ b/frontend/src/pages/administrar_empleados.jsx
@@ -1,44 +1,37 @@
+// src/pages/administrar_empleados.jsx
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Edit, Trash2 } from "../iconos";
+import { getCurrentUserRole } from "../hooks/auth";
 import "./pages-styles/administrar_empleados.css";
 
 export default function AdministrarEmpleados() {
+  const role = getCurrentUserRole();
+  const isSuper = role === "superadmin";
+  const registerPath = isSuper
+    ? "/register_gerentes_y_trabajadores"
+    : "/register_trabajadores";
+
   const [empleados, setEmpleados] = useState([]);
 
   useEffect(() => {
-    // Aquí conectamos con el backend real
-
-    // Por ahora, datos de prueba
+    // TODO: fetch real a /api/empleados cuando esté listo
     setEmpleados([
-      { id: 1, nombre: "JUAN PEREZ", cargo: "COTIZACIÓN" },
-      { id: 2, nombre: "ANA LÓPEZ", cargo: "COTIZACIÓN" },
-      { id: 3, nombre: "CARLOS RAMOS", cargo: "COTIZACIÓN" },
-      { id: 4, nombre: "LUCÍA MEJÍA", cargo: "REPARACIÓN" },
-      { id: 5, nombre: "JORGE SOTO", cargo: "COTIZACIÓN" },
-      { id: 6, nombre: "MARÍA NAVA", cargo: "REPARACIÓN" },
-      { id: 7, nombre: "RAÚL REYES", cargo: "COTIZACIÓN" },
-      { id: 8, nombre: "KARLA MENA", cargo: "REPARACIÓN" },
-      { id: 9, nombre: "MARIO DÍAZ", cargo: "COTIZACIÓN" },
+      { id: 1, nombre: "JUAN PEREZ", cargo: "COTIZACIÓN", tipo: "empleado" },
+      { id: 2, nombre: "GERENTE DEMO", cargo: "GERENTE", tipo: "gerente" },
+      { id: 3, nombre: "ANA LÓPEZ", cargo: "COTIZACIÓN", tipo: "empleado" },
     ]);
   }, []);
 
-  const handleDelete = (emp) => {
-    if (confirm(`¿Eliminar a ${emp.nombre}?`)) {
-      setEmpleados((prev) => prev.filter((e) => e.id !== emp.id));
-    }
-  };
-
-  const handleEdit = (emp) => {
-    alert(`Editar a ${emp.nombre}`);
-  };
+  // Si NO eres superadmin, no muestres gerentes
+  const visible = isSuper ? empleados : empleados.filter(e => e.tipo !== "gerente");
 
   return (
     <div className="container py-5 administrar-page">
-      <h2 className="text-center administrar-title">Administración de gerentes</h2>
+      <h2 className="text-center administrar-title">Administración de empleados</h2>
 
       <div className="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
-        {empleados.map((emp) => (
+        {visible.map((emp) => (
           <div className="col" key={emp.id}>
             <div className="card empleado-card">
               <div className="card-body d-flex justify-content-between align-items-center">
@@ -47,16 +40,10 @@ export default function AdministrarEmpleados() {
                   <div className="text-muted small">{emp.cargo}</div>
                 </div>
                 <div className="d-flex gap-2">
-                  <button
-                    className="btn btn-light btn-sm icon-btn"
-                    onClick={() => handleEdit(emp)}
-                  >
+                  <button className="btn btn-light btn-sm icon-btn" title="Editar">
                     <Edit size={18} />
                   </button>
-                  <button
-                    className="btn btn-light btn-sm icon-btn"
-                    onClick={() => handleDelete(emp)}
-                  >
+                  <button className="btn btn-light btn-sm icon-btn" title="Eliminar">
                     <Trash2 size={18} />
                   </button>
                 </div>
@@ -66,11 +53,9 @@ export default function AdministrarEmpleados() {
         ))}
       </div>
 
+      {/* Botón de alta según rol */}
       <div className="text-center mt-4">
-        <Link
-          to="/register_gerentes_y_trabajadores"
-          className="btn btn-danger fw-bold px-4 add-btn"
-        >
+        <Link to={registerPath} className="btn btn-danger fw-bold px-4 add-btn">
           Agregar Trabajador +
         </Link>
       </div>

--- a/frontend/src/pages/vista_superadministrador.jsx
+++ b/frontend/src/pages/vista_superadministrador.jsx
@@ -92,15 +92,6 @@ const VistaSuperadministrador = () => {
                 </div>
               </div>
 
-              {/* Contenedor dinámico */}
-              <div
-                className={vistaLista ? "turnos-list" : "turnos-grid"}
-                style={{ padding: "1rem" }}
-              >
-                <WorkerTurnCard filtroBusqueda={busqueda} mostrarCargo={true} />
-
-              </div>
-
               {/* Botón para finalizar el día */}
               <div className="text-center mt-3 mb-5">
                 <button
@@ -110,10 +101,31 @@ const VistaSuperadministrador = () => {
                   {diaFinalizado ? "Iniciar Nuevo Día" : "Finalizar Día"}
                 </button>
 
-                <button className="btn btn-custom ms-2" onClick={() => navigate("/historial")}>
+                <button
+                  className="btn btn-custom ms-2"
+                  onClick={() => navigate("/historial")}
+                >
                   Historial
                 </button>
+
+                {/* Nuevo botón Administrar */}
+                <button
+                  className="btn btn-custom ms-2"
+                  onClick={() => navigate("/administrar_empleados")}
+                >
+                  Administrar 
+                </button>
               </div>
+
+              {/* Contenedor dinámico */}
+              <div
+                className={vistaLista ? "turnos-list" : "turnos-grid"}
+                style={{ padding: "1rem" }}
+              >
+                <WorkerTurnCard filtroBusqueda={busqueda} mostrarCargo={true} />
+
+              </div>
+
             </div>
           </div>
         </div>


### PR DESCRIPTION
Estuve probando el módulo de administración de empleados usando simulaciones en el localStorage. Lo que hice fue crear distintos perfiles: superadmin, gerente y empleado, para ver cómo respondía el sistema. Con el superadmin pude visualizar tanto gerentes como empleados, y el botón me mandó al registro general. Cuando cambié a gerente, solo me aparecieron empleados y el botón redirigió al registro de trabajadores. En el caso del empleado normal, el guard me sacó directo al inicio, lo que confirmó que las validaciones estaban funcionando.

Por ahora ya funciona sin simulación, ya que creé el botón que redirige al documento administrar_empleados. Solo me falta integrarlo también en la vista de gerente para completar la funcionalidad.