### PR TITLE
Creacion de botones en vista de gerente y superadmin

### DIFF
--- a/frontend/src/pages/administrar_empleados.jsx
+++ b/frontend/src/pages/administrar_empleados.jsx
@@ -1,7 +1,7 @@
 // src/pages/administrar_empleados.jsx
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { Edit, Trash2 } from "../iconos";
+import { Edit, Trash2, ArrowLeft } from "../iconos";
 import { getCurrentUserRole } from "../hooks/auth";
 import "./pages-styles/administrar_empleados.css";
 
@@ -13,6 +13,17 @@ export default function AdministrarEmpleados() {
     ? "/register_gerentes_y_trabajadores"
     : "/register_trabajadores";
   const [empleados, setEmpleados] = useState([]);
+
+  const empleado = JSON.parse(localStorage.getItem("empleado") || "null");
+  const fallback = (empleado?.ROL || "").toLowerCase() === "superadmin"
+    ? "/vista_superadministrador"
+    : "/vista_gerente";
+
+  const goBack = () => {
+    if (window.history.length > 1) navigate(-1);
+    else navigate(fallback, { replace: true });
+  };
+
   
   // Función para eliminar empleado
   const handleDelete = (id) => {
@@ -59,7 +70,21 @@ export default function AdministrarEmpleados() {
 
   return (
     <div className="container py-5 administrar-page">
-      <h2 className="text-center administrar-title">Administración de empleados</h2>
+      <div className="header-with-back">
+        <button
+          className="btn btn-danger fw-bold back-btn"
+          onClick={() => navigate(-1)}
+          title="Regresar"
+          aria-label="Regresar"
+        >
+          <ArrowLeft size={20} />
+        </button>
+
+        <h2 className="titulo-seccion">ADMINISTRACIÓN DE EMPLEADOS</h2>
+
+        {/* Spacer para mantener centrado */}
+        <div className="back-btn-spacer"></div>
+      </div>
 
       <div className="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
         {visible.map((emp) => (

--- a/frontend/src/pages/historial.jsx
+++ b/frontend/src/pages/historial.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Calendar, User, Wrench, CheckCircle, AlertTriangle } from "../iconos";
+import { ArrowLeft, Calendar, User, Wrench, CheckCircle, AlertTriangle } from "../iconos";
 import { fetchHistorialTurnos } from "../api/turnosApi.js";
 import "react-datepicker/dist/react-datepicker.css";
+import "./pages-styles/historial.css";
 
 const ESTADO_BADGE = {
   pendiente: "warning",
@@ -93,6 +94,17 @@ const Historial = () => {
 
   const key = useMemo(() => JSON.stringify({ q, estado, page }), [q, estado, page]);
 
+  const empleado = JSON.parse(localStorage.getItem("empleado") || "null");
+  const fallback = (empleado?.ROL || "").toLowerCase() === "superadmin"
+    ? "/vista_superadministrador"
+    : "/vista_gerente";
+
+  const goBack = () => {
+    if (window.history.length > 1) navigate(-1);
+    else navigate(fallback, { replace: true });
+  };
+
+
   useEffect(() => {
     const controller = new AbortController();
     setLoading(true);
@@ -119,17 +131,22 @@ const Historial = () => {
       className="container py-5"
       style={{ marginTop: "4rem", paddingBottom: "3rem" }}
     >
-      <h2
-        className="text-center mb-4"
-        style={{
-          color: "#fff",
-          fontWeight: "700",
-          textShadow: "1px 1px 3px rgba(0,0,0,0.4)",
-          fontSize: "3rem",
-        }}
-      >
-        Historial de turnos
-      </h2>
+      <div className="header-with-back">
+        <button
+          className="btn btn-danger back-btn"
+          onClick={goBack}
+          title="Regresar"
+          aria-label="Regresar"
+        >
+          <ArrowLeft size={18} />
+        </button>
+
+        <h2 className="titulo-seccion">Historial de turnos</h2>
+
+        {/* Spacer para mantener el título centrado */}
+        <div className="back-btn-spacer" />
+      </div>
+
 
       {/* Filtros */}
       <div className="card shadow mb-4" style={{ borderRadius: "12px", backgroundColor: "rgba(255,255,255,0.85)" }}>

--- a/frontend/src/pages/pages-styles/admin.css
+++ b/frontend/src/pages/pages-styles/admin.css
@@ -34,3 +34,95 @@
     margin: 0;
     overflow-x: hidden;
 }
+
+.hero-section {
+    background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
+    color: white;
+    padding: 4rem 0;
+    margin-top: 56px; /* Altura de la navbar */
+    margin-bottom: auto;
+    position: relative;
+    width: 100%;
+    max-width: 100vw;
+    left: 0;
+    right: 0;
+}
+  
+.hero-section .text-center {
+    max-width: 1200px;         /* opcional: limita contenido centrado */
+    margin: 0 auto;
+    padding: 0 15px;
+}
+
+.hero-section::after {
+    content: '';
+    position: absolute;
+    bottom: -40px;
+    left: 0;
+    width: 100%;
+    height: 100px;
+    background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
+    clip-path: ellipse(70% 100% at 50% 0%);
+}
+
+.full-width-container {
+    width: 100vw;
+    padding: 0;
+    margin: 0;
+    overflow-x: hidden;
+}
+
+/* grupo de botones arriba, centrado */
+.acciones-header {
+  flex-wrap: wrap;
+}
+
+/* tamaño compacto consistente */
+.btn-compacto {
+  display: inline-block !important;
+  min-width: 120px;   /* ancho fijo más corto */
+  max-width: 150px;   /* evita que se estiren de más */
+  padding: 6px 12px;  /* altura y ancho equilibrados */
+  font-size: 0.9rem;
+  font-weight: 600;
+  border-radius: 8px;
+  text-align: center;
+}
+
+/* Contenedor: botón izquierda + título centrado + spacer derecha */
+.header-with-back{
+  display: flex;
+  align-items: center;
+  justify-content: center;     /* centra el conjunto */
+  gap: 12px;
+  margin-bottom: 1rem;
+}
+
+/* El spacer equilibra el ancho del botón para mantener el título centrado */
+.back-btn-spacer{
+  width: 38px;                 /* parecido al ancho del botón */
+  height: 1px;                 /* no visible */
+}
+
+/* Botón redondo sutil */
+.back-btn{
+  border-radius: 999px;
+  padding: 6px 10px;
+  box-shadow: 0 2px 4px rgba(0,0,0,.08);
+}
+
+/* Título grande centrado (opcional unifica estilos) */
+.titulo-seccion{
+  color: #fff;
+  font-weight: 800;
+  text-align: center;
+  text-shadow: 1px 1px 3px rgba(0,0,0,.35);
+  font-size: clamp(1.5rem, 4vw, 3rem);
+  margin: 0;
+}
+
+
+/* opcional: en pantallas chicas, que no se apachurren */
+@media (max-width: 576px) {
+  .btn-compacto { min-width: 120px; font-size: 0.9rem; }
+}

--- a/frontend/src/pages/pages-styles/administrar_empleados.css
+++ b/frontend/src/pages/pages-styles/administrar_empleados.css
@@ -44,3 +44,27 @@
   border-radius: 8px;
   padding: 0.6rem 1.5rem;
 }
+
+/* Contenedor: botón izquierda + título centrado + spacer derecha */
+.header-with-back{
+  display: flex;
+  align-items: center;
+  justify-content: center;     /* centra el conjunto */
+  gap: 12px;
+  margin-bottom: 1rem;
+}
+
+.back-btn {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.375rem 0.75rem;  /* igual a Bootstrap btn */
+  font-size: 1rem;
+  border-radius: 0.375rem;   /* mismo radio que Iniciar sesión */
+}
+
+.back-btn-spacer {
+  width: 200px;   /* mismo ancho aprox que el botón de iniciar sesión */
+  height: 1px;
+}
+

--- a/frontend/src/pages/pages-styles/historial.css
+++ b/frontend/src/pages/pages-styles/historial.css
@@ -47,9 +47,43 @@
 }
 
 .historial-pagination .btn-group .btn {
-    color: black;
+  color: black;
   border-radius: 999px;  /* botones redonditos */
   padding: 0.5rem 1.2rem;
   background: #fff;
+}
+
+/* Contenedor: botón izquierda + título centrado + spacer derecha */
+.header-with-back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 1rem;
+}
+
+/* Botón regresar */
+.back-btn {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.375rem 0.75rem;  /* igual a Bootstrap btn */
+  font-size: 1rem;
+  border-radius: 0.375rem;   /* mismo radio que Iniciar sesión */
+}
+
+/* Spacer con ancho del botón para mantener el título centrado */
+.back-btn-spacer {
+  width: 200px;   /* mismo ancho aprox que el botón de iniciar sesión */
+  height: 1px;
+}
+/* Título grande centrado (opcional unifica estilos) */
+.titulo-seccion{
+  color: #fff;
+  font-weight: 800;
+  text-align: center;
+  text-shadow: 1px 1px 3px rgba(0,0,0,.35);
+  font-size: clamp(1.5rem, 4vw, 3rem);
+  margin: 10px 200px 20px;
 }
 

--- a/frontend/src/pages/pages-styles/superadmin.css
+++ b/frontend/src/pages/pages-styles/superadmin.css
@@ -63,3 +63,65 @@
   background-color: #e93838;
   color: white;
 }
+
+/* contenedor centrado y del tamaño justo del grupo */
+.acciones-centradas{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;              /* separación entre botones */
+  width: fit-content;     /* no ocupa todo el ancho */
+}
+
+/* tamaño compacto consistente (como tu maqueta) */
+.btn-compacto{
+  display: inline-block;
+  min-width: 140px;       /* prueba 130–160 según veas */
+  padding: 8px 16px;
+  font-weight: 700;
+  border-radius: 10px;
+  font-size: 0.95rem;
+}
+
+/* Contenedor: botón izquierda + título centrado + spacer derecha */
+.header-with-back{
+  display: flex;
+  align-items: center;
+  justify-content: center;     /* centra el conjunto */
+  gap: 12px;
+  margin-bottom: 1rem;
+}
+
+/* El spacer equilibra el ancho del botón para mantener el título centrado */
+.back-btn-spacer{
+  width: 38px;                 /* parecido al ancho del botón */
+  height: 1px;                 /* no visible */
+}
+
+/* Botón redondo sutil */
+.back-btn{
+  border-radius: 999px;
+  padding: 6px 10px;
+  box-shadow: 0 2px 4px rgba(0,0,0,.08);
+}
+
+/* Título grande centrado (opcional unifica estilos) */
+.titulo-seccion{
+  color: #fff;
+  font-weight: 800;
+  text-align: center;
+  text-shadow: 1px 1px 3px rgba(0,0,0,.35);
+  font-size: clamp(1.5rem, 4vw, 3rem);
+  margin: 0;
+}
+
+
+/* responsivo en pantallas chicas */
+@media (max-width: 576px){
+  .btn-compacto{
+    min-width: 120px;
+    padding: 7px 14px;
+    font-size: 0.9rem;
+  }
+}
+

--- a/frontend/src/pages/vista_gerente.jsx
+++ b/frontend/src/pages/vista_gerente.jsx
@@ -100,6 +100,22 @@ const VistaGerente = () => {
                 </div>
               </div>
 
+              {/*Solo estos dos botones, centrados y compactos */}
+              <div className="d-flex justify-content-center gap-3 mb-4">
+                <button
+                  className="btn btn-danger btn-compacto"
+                  onClick={() => navigate("/historial")}
+                >
+                  Historial
+                </button>
+                <button
+                  className="btn btn-danger btn-compacto"
+                  onClick={() => navigate("/administrar_empleados")}
+                >
+                  Administrar
+                </button>
+              </div>
+
               {/* Contenedor dinámico */}
               <div
                 className={vistaLista ? "turnos-list" : "turnos-grid"}

--- a/frontend/src/pages/vista_superadministrador.jsx
+++ b/frontend/src/pages/vista_superadministrador.jsx
@@ -92,30 +92,30 @@ const VistaSuperadministrador = () => {
                 </div>
               </div>
 
-              {/* Botón para finalizar el día */}
-              <div className="text-center mt-3 mb-5">
+              {/* Botones centrados */}
+              <div className="acciones-centradas mx-auto mb-5">
                 <button
-                  className={`btn ${diaFinalizado ? "btn-success" : "btn-danger"}`}
+                  className={`btn ${diaFinalizado ? "btn-success" : "btn-danger"} btn-compacto`}
                   onClick={toggleDia}
                 >
-                  {diaFinalizado ? "Iniciar Nuevo Día" : "Finalizar Día"}
+                  {diaFinalizado ? "Iniciar Nuevo Día" : "Finalizar día"}
                 </button>
 
                 <button
-                  className="btn btn-custom ms-2"
+                  className="btn btn-danger btn-compacto"
                   onClick={() => navigate("/historial")}
                 >
                   Historial
                 </button>
 
-                {/* Nuevo botón Administrar */}
                 <button
-                  className="btn btn-custom ms-2"
+                  className="btn btn-danger btn-compacto"
                   onClick={() => navigate("/administrar_empleados")}
                 >
-                  Administrar 
+                  Administrar
                 </button>
               </div>
+
 
               {/* Contenedor dinámico */}
               <div


### PR DESCRIPTION
Se agregaron los botones de Administrar, Finalizar día e Historial en las vistas de Gerente y Superadministrador.

Validaciones dinámicas:
-Si el usuario es superadmin, se muestran los 3 botones.
-Si el usuario es gerente, solo se muestran Historial y Administrar (sin la opción de Finalizar día).
-Cada botón ya redirecciona correctamente a su respectiva vista.

Nota: actualmente existe un pequeño detalle de estilo, si se ajusta el tamaño de uno de los botones (Historial o Administrar), ambos se ven afectados al estar en el mismo grupo de estilos. Falta refinar la separación de clases para que sean independientes.
Esto ya deja funcional la navegación y las validaciones de rol, quedando pendiente solo pulir los estilos para que los botones mantengan tamaños consistentes.