### PR TITLE
modificacion turno siguiente

### DIFF
--- a/backend/app/Http/Controllers/TurnController.php
+++ b/backend/app/Http/Controllers/TurnController.php
@@ -131,13 +131,25 @@ class TurnController extends Controller
     // app/Http/Controllers/TurnoController.php
     public function enAtencion()
     {
-        $turno = Turno::where('ESTATUS', 'En_atencion')->first(); // solo uno
+        $turno = Turno::where('ESTATUS', 'En_atencion')
+            ->orderBy('ATENCION_EN', 'desc') // el más reciente primero
+            ->first();
+
         if ($turno) {
-            return response()->json(['turno' => $turno], 200);
+            return response()->json(['turno' => [
+                'ID_TURNO' => $turno->ID_TURNO,
+                'cliente' => $turno->NOMBRE . ' ' . $turno->APELLIDOS,
+                'ID_EMPLEADO' => $turno->ID_EMPLEADO,
+                'estado' => $turno->ESTATUS,
+                'fecha_atencion' => $turno->fecha,
+                'hora_atencion' => $turno->hora_atencion,
+                'ATENCION_EN' => $turno->ATENCION_EN,
+            ]], 200);
         } else {
             return response()->json(['turno' => null], 200);
         }
     }
+
 
     public function store(Request $request)
     {
@@ -219,6 +231,7 @@ class TurnController extends Controller
         if ($siguiente) {
             $siguiente->ID_EMPLEADO = $empleadoId;
             $siguiente->ESTATUS = 'En_atencion';
+            $siguiente->ATENCION_EN = now();
             $siguiente->save();
         }
 

--- a/frontend/src/api/turnosApi.js
+++ b/frontend/src/api/turnosApi.js
@@ -29,4 +29,10 @@ export async function pasarTurno(empleadoId, cargo, options = {}) {
   return res.json();
 }
 
+export async function fetchTurnoEnAtencion(options = {}) {
+  const res = await fetch("http://127.0.0.1:8000/api/turnos/en_atencion", options);
+  if (!res.ok) throw new Error("Error al obtener turno en atención");
+  return res.json();
+}
+
 

--- a/frontend/src/components/CurrentTurnCard.jsx
+++ b/frontend/src/components/CurrentTurnCard.jsx
@@ -1,6 +1,7 @@
 // src/components/CurrentTurnCard.jsx
 import React, { useEffect, useState } from 'react';
 import { Wrench, Clock, Zap } from '../iconos';
+import { fetchTurnoEnAtencion } from '../api/turnosApi';
 import './CurrentTurnCard.css';
 
 const CurrentTurnCard = ({ variant, onPasarTurno }) => {
@@ -21,7 +22,7 @@ const CurrentTurnCard = ({ variant, onPasarTurno }) => {
             : `Pase al módulo: ${data.turno.ID_EMPLEADO}`, // solo si no es reparación
           name: `${data.turno.NOMBRE} ${data.turno.APELLIDOS}`,
           priority: data.turno.PRIORIDAD || 'baja',
-          started_at: data.turno.HORA,
+          started_at: new Date(data.turno.ATENCION_EN).toLocaleString(),
           isReparacion: data.turno.ID_AREA === 1, // para badge
         };
 
@@ -43,7 +44,7 @@ const CurrentTurnCard = ({ variant, onPasarTurno }) => {
     return () => clearInterval(interval);
   }, []);
 
-  if (!turno) return <p>No hay turno en atención.</p>;
+  if (!turno) return <div className="current-turn-card h-100 position-relative flex-fill text-center"><p>No hay turno en atención.</p></div>;
 
   const isSuperadmin = variant === 'superadmin';
 


### PR DESCRIPTION
se muestra el ultimo turno en atencion, agregue a la base de datos el campo atencion_en para guardar la fecha y hora en que se paso al turno y con esto poder mostrar el ultimo turno que se puso en atencion, ademas de cambiar el refresh a 1 segundo para que se cambie mas rapido