### PR TITLE
arreglo de administrar empleados

### DIFF
--- a/frontend/src/pages/administrar_empleados.jsx
+++ b/frontend/src/pages/administrar_empleados.jsx
@@ -8,37 +8,25 @@ import { motion, AnimatePresence } from "framer-motion";
 
 export default function AdministrarEmpleados() {
   const navigate = useNavigate();
-  const [nombreEmpleado, setNombreEmpleado] = useState("");
-  const [filtro, setFiltro] = useState("");
   const [empleados, setEmpleados] = useState([]);
 
-  // Protegemos la vista y bloqueamos retroceso
+  // ---- Guardas / sesión ----
   useEffect(() => {
     const storedEmpleado = JSON.parse(localStorage.getItem("empleado"));
-
     if (!storedEmpleado) {
       navigate("/login", { replace: true });
       return;
     }
 
-    setNombreEmpleado(storedEmpleado.NOMBRE);
-    setFiltro(storedEmpleado.CARGO.toLowerCase());
-
-    // Bloquear solo retroceso del navegador
     const handlePopState = () => {
       window.history.pushState(null, "", window.location.href);
     };
-
-    // Agregar un estado extra para que el historial tenga "bloqueo"
     window.history.pushState(null, "", window.location.href);
     window.addEventListener("popstate", handlePopState);
-
-    return () => {
-      window.removeEventListener("popstate", handlePopState);
-    };
+    return () => window.removeEventListener("popstate", handlePopState);
   }, [navigate]);
 
-  const role = getCurrentUserRole(); // "superadmin" o "gerente"
+  const role = getCurrentUserRole(); // "superadmin" | "gerente"
   const isSuper = role === "superadmin";
   const storedEmpleado = JSON.parse(localStorage.getItem("empleado") || "null");
 
@@ -46,27 +34,14 @@ export default function AdministrarEmpleados() {
     ? "/register_gerentes_y_trabajadores"
     : "/register_trabajadores";
 
-  const fallback =
-    (storedEmpleado?.ROL || "").toLowerCase() === "superadmin"
-      ? "/vista_superadministrador"
-      : "/vista_gerente";
-
-  // Botón de regresar dentro de la página
   const goBack = () => {
-    const storedEmpleado = JSON.parse(localStorage.getItem("empleado") || "null");
-    if (!storedEmpleado) return navigate("/login", { replace: true });
-    
-    const fallback =
-      storedEmpleado.ID_ROL === 0
-        ? "/vista_superadministrador"
-        : "/vista_gerente";
-    
+    const stored = JSON.parse(localStorage.getItem("empleado") || "null");
+    if (!stored) return navigate("/login", { replace: true });
+    const fallback = stored.ID_ROL === 0 ? "/vista_superadministrador" : "/vista_gerente";
     navigate(fallback, { replace: true });
   };
 
-
-
-  // Cargar empleados
+  // ---- Cargar empleados ----
   useEffect(() => {
     fetch("http://127.0.0.1:8000/api/empleados")
       .then((res) => {
@@ -78,126 +53,219 @@ export default function AdministrarEmpleados() {
           id: e.ID_EMPLEADO,
           ID_EMPLEADO: e.ID_EMPLEADO,
           nombre: e.NOMBRE,
-          cargo: e.CARGO,
-          tipo:
-            e.ID_ROL === 0
-              ? "Administrador"
-              : e.ID_ROL === 1
-              ? "Gerente"
-              : "Empleado",
+          cargo: (e.CARGO || "").toLowerCase(), // cotizacion | reparacion | general ...
+          tipo: e.ID_ROL === 0 ? "Administrador" : e.ID_ROL === 1 ? "Gerente" : "Empleado",
           ID_ROL: e.ID_ROL,
         }));
         setEmpleados(empleadosNormalizados);
       })
-      .catch((err) => console.error(err));
+      .catch(console.error);
   }, []);
 
-  // Eliminar empleado
-  const handleDelete = (id) => {
+  // ---- Helpers ----
+  const editar = (id) => navigate(`/editar_empleado/${id}`);
+  const eliminar = (id) => {
     if (!window.confirm("¿Seguro que quieres eliminar este empleado?")) return;
-
     fetch(`http://127.0.0.1:8000/api/empleados/${id}`, { method: "DELETE" })
       .then((res) => {
         if (!res.ok) throw new Error("Error al eliminar");
         setEmpleados((prev) => prev.filter((emp) => emp.id !== id));
       })
-      .catch((err) => console.error(err));
+      .catch(console.error);
   };
+  const capital = (s = "") => s.charAt(0).toUpperCase() + s.slice(1);
 
-  // Filtrar empleados según rol
-  let visible = [];
+  // ---- Visibilidad por rol ----
+  let visibles = [];
   if (isSuper) {
-    visible = empleados.filter((e) => e.tipo !== "Administrador");
+    visibles = empleados.filter((e) => e.tipo !== "Administrador");
   } else if (role === "gerente") {
-    visible = empleados.filter(
-      (e) => e.ID_ROL === 2 && e.cargo === storedEmpleado?.CARGO
-    );
+    // Un gerente solo ve empleados de su área
+    visibles = empleados.filter((e) => e.ID_ROL === 2 && e.cargo === (storedEmpleado?.CARGO || "").toLowerCase());
   }
+
+  // ---- Grupos para el layout por columnas ----
+  const gerentes = isSuper ? visibles.filter((e) => e.tipo === "Gerente") : [];
+  const cotizacion = visibles.filter((e) => e.tipo !== "Gerente" && e.cargo === "cotizacion");
+  const reparacion = visibles.filter((e) => e.tipo !== "Gerente" && e.cargo === "reparacion");
+
+  const gruposUI = isSuper
+    ? [
+        { key: "gerentes", title: "Gerentes", items: gerentes },
+        { key: "cotizacion", title: "Cotización", items: cotizacion },
+        { key: "reparacion", title: "Reparación", items: reparacion },
+      ]
+    : [
+        { key: "area", title: `Área de ${capital(storedEmpleado?.CARGO || "")}`, items: visibles },
+      ];
 
   return (
     <AnimatePresence>
       <motion.div
-        className="full-width-container"
+        className="full-width-container administrar-page"
         initial={{ opacity: 0, x: 50 }}
         animate={{ opacity: 1, x: 0 }}
         exit={{ opacity: 0, x: -50 }}
         transition={{ duration: 0.5 }}
       >
-        {/* HERO SECTION */}
+        {/* HERO */}
         <div className="hero-section">
-          <div className="text-center mt-2">
+          <div className="hero-row">
             <button
-              className="btn_volver me-2"
+              className="btn_volver hero-back"
               onClick={goBack}
-              title="Regresar"
               aria-label="Regresar"
+              title="Regresar"
             >
-              <ArrowLeft size={20} />
+              <ArrowLeft size={22} />
             </button>
-            <h3 className="display-3 fw-bold mb-1">Administración de Empleados</h3>
-            <p className="lead opacity-75">
-              Gestiona gerentes y trabajadores de manera rápida y sencilla.
-            </p>
-          </div>
-        </div>
+            <div className="hero-copy text-center">
+              <h3 className="display-3 fw-bold mb-1">Administración de Empleados</h3>
+                <p className="lead opacity-75">
+                  Gestiona gerentes y trabajadores de manera rápida y sencilla.
+                </p>
+              </div>
 
-        {/* CONTENIDO PRINCIPAL */}
-        <div className="container" style={{ marginTop: "-5rem", paddingBottom: "1rem" }}>
+          {/* Spacer derecho para mantener el centrado simétrico */}
+          <div aria-hidden="true" className="hero-right-spacer" />
+        </div>
+      </div>
+
+
+
+        {/* CONTENIDO */}
+        <div className="container" style={{ marginTop: "0", paddingBottom: "1rem" }}>
           <div className="header d-flex align-items-center mb-4">
-            <button
-              className="btn_volver me-3"
-              onClick={goBack}
-              title="Regresar"
-              aria-label="Regresar"
-            >
-              <ArrowLeft size={20} />
-            </button>
-            <h2 className="titulo mb-0">Lista de Empleados</h2>
             {!isSuper && storedEmpleado?.CARGO && (
-              <p className="text-muted ms-3 mb-0">(Gerente de {storedEmpleado.CARGO})</p>
+              <p className="text-muted ms-3 mb-0">(Gerente de {capital(storedEmpleado.CARGO)})</p>
             )}
           </div>
 
-          <div className="row row-cols-1 row-cols-md-2 g-3 col-lg-100">
-            {visible.map((emp) => (
-              <div className="col" key={emp.id}>
-                <div className="card empleado-card">
-                  <div className="card-body d-flex justify-content-between align-items-center">
-                    <div>
-                      <div className="fw-bold">{emp.nombre}</div>
-                      <div className="text-muted small">
-                        {emp.tipo === "Empleado" && emp.cargo === "General"
-                          ? "Empleado General"
-                          : `${emp.tipo} de ${emp.cargo}`}
+          {/* === LAYOUT: GERENTES + PANEL TRABAJADORES (con 2 subcolumnas) === */}
+          <div className="grilla-grupos">
+
+            {/* Columna: Gerentes */}
+            <section className="grupo-col">
+              <h3 className="grupo-title">Gerentes</h3>
+
+              <div className="grupo-cards">
+                {gerentes.length === 0 && <p className="grupo-empty">Cargando...</p>}
+
+                {gerentes.map((emp) => (
+                  <article className="card empleado-card" key={emp.id}>
+                    <div className="card-body d-flex justify-content-between align-items-center">
+                      <div>
+                        <div className="fw-bold">{emp.nombre}</div>
+                        {/* Mostrar el ÁREA del gerente */}
+                        <div className="text-muted small">{capital(emp.cargo)}</div>
+                      </div>
+
+                      <div className="d-flex gap-2">
+                        <button
+                          className="btn btn-light btn-sm icon-btn icon-edit"
+                          title="Editar"
+                          onClick={() => editar(emp.id)}
+                        >
+                          <Edit size={18} />
+                        </button>
+                        <button
+                          className="btn btn-light btn-sm icon-btn icon-delete"
+                          title="Eliminar"
+                          onClick={() => eliminar(emp.id)}
+                        >
+                          <Trash2 size={18} />
+                        </button>
                       </div>
                     </div>
-                    <div className="d-flex gap-2">
-                      <button
-                        className="btn btn-light btn-sm icon-btn"
-                        title="Editar"
-                        onClick={() => navigate(`/editar_empleado/${emp.id}`)}
-                      >
-                        <Edit size={18} />
-                      </button>
-                      <button
-                        className="btn btn-light btn-sm icon-btn"
-                        title="Eliminar"
-                        onClick={() => handleDelete(emp.id)}
-                      >
-                        <Trash2 size={18} />
-                      </button>
-                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            {/* Panel: Trabajadores (ocupa 2 columnas en desktop) */}
+            <section className="grupo-col trabajadores-col">
+              <h3 className="grupo-title">Trabajadores</h3>
+
+              <div className="subgrilla">
+                {/* Subcol: Cotización */}
+                <div className="subcol">
+                  <h4 className="sub-title">Cotización</h4>
+                  <div className="grupo-cards">
+                    {cotizacion.length === 0 && <p className="grupo-empty">Cargando...</p>}
+
+                    {cotizacion.map((emp) => (
+                      <article className="card empleado-card" key={emp.id}>
+                        <div className="card-body d-flex justify-content-between align-items-center">
+                          <div>
+                            <div className="fw-bold">{emp.nombre}</div>
+                            <div className="text-muted small">Empleado de Cotización</div>
+                          </div>
+
+                          <div className="d-flex gap-2">
+                            <button
+                              className="btn btn-light btn-sm icon-btn icon-edit"
+                              title="Editar"
+                              onClick={() => editar(emp.id)}
+                            >
+                              <Edit size={18} />
+                            </button>
+                            <button
+                              className="btn btn-light btn-sm icon-btn icon-delete"
+                              title="Eliminar"
+                              onClick={() => eliminar(emp.id)}
+                            >
+                              <Trash2 size={18} />
+                            </button>
+                          </div>
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Subcol: Reparación */}
+                <div className="subcol">
+                  <h4 className="sub-title">Reparación</h4>
+                  <div className="grupo-cards">
+                    {reparacion.length === 0 && <p className="grupo-empty">Cargando...</p>}
+
+                    {reparacion.map((emp) => (
+                      <article className="card empleado-card" key={emp.id}>
+                        <div className="card-body d-flex justify-content-between align-items-center">
+                          <div>
+                            <div className="fw-bold">{emp.nombre}</div>
+                            <div className="text-muted small">Empleado de Reparación</div>
+                          </div>
+
+                          <div className="d-flex gap-2">
+                            <button
+                              className="btn btn-light btn-sm icon-btn icon-edit"
+                              title="Editar"
+                              onClick={() => editar(emp.id)}
+                            >
+                              <Edit size={18} />
+                            </button>
+                            <button
+                              className="btn btn-light btn-sm icon-btn icon-delete"
+                              title="Eliminar"
+                              onClick={() => eliminar(emp.id)}
+                            >
+                              <Trash2 size={18} />
+                            </button>
+                          </div>
+                        </div>
+                      </article>
+                    ))}
                   </div>
                 </div>
               </div>
-            ))}
+            </section>
+
           </div>
 
+
           <div className="text-center mt-4">
-            <Link
-              to={registerPath}
-              className="btn btn-danger fw-bold px-4 add-btn"
-            >
+            <Link to={registerPath} className="btn btn-danger fw-bold px-4 add-btn">
               Agregar Trabajador +
             </Link>
           </div>

--- a/frontend/src/pages/pages-styles/administrar_empleados.css
+++ b/frontend/src/pages/pages-styles/administrar_empleados.css
@@ -20,21 +20,48 @@
   text-align: center;
 }
 
-.btn_volver {
-  background-color: #cf2435;
-  border: none;
-  color: white;
-  padding: 0.5rem 0.7rem;
-  display: flex;
+/* El hero sirve de referencia para posicionar la flecha */
+.hero-section { padding: 34px 0 80px; }
+
+/* Fila del hero: [flecha] [título centrado] [spacer] */
+.hero-row{
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 44px 1fr 44px; /* flecha, contenido, espejo */
   align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-  width: 2.5rem;
+  gap: 12px;
 }
 
-.btn_volver:hover {
-  background-color: #a31522;
+/* Botón circular estilo blanco,*/
+.btn_volver.hero-back{
+  position: static;
+  width: 44px; 
+  height: 44px;
+  border-radius: 999px;
+  background: transparent;
+  border: 2px solid #fff;
+  color: #fff;
+  display: flex; 
+  align-items: center; 
+  justify-content: center;
+  box-shadow: 0 2px 10px rgba(0,0,0,.25);
+  transition: background .2s, transform .1s;
+}
+.btn_volver.hero-back:hover { background: rgba(255,255,255,.12); transform: translateY(-1px); }
+.btn_volver.hero-back svg { stroke: currentColor; }
+
+/* Spacer del lado derecho del mismo tamaño que el botón */
+.hero-right-spacer{ width: 44px; height: 44px; }
+
+@media (max-width: 420px){
+  .hero-row{ 
+    grid-template-columns: 40px 1fr 40px; 
+  }
+  .btn_volver.hero-back, .hero-right-spacer{ 
+    width: 40px; 
+    height: 40px; 
+  }
 }
 
 /* Card de empleado */
@@ -65,8 +92,8 @@
 
 /* Botón agregar */
 .add-btn {
-  border-radius: 8px;
-  padding: 0.6rem 1.5rem;
+  border-radius: 10px;
+  padding: 0.65rem 1.5rem;
 }
 
 /* Contenedor: botón izquierda + título centrado + spacer derecha */
@@ -84,11 +111,126 @@
   align-items: center;
   padding: 0.375rem 0.75rem;  /* igual a Bootstrap btn */
   font-size: 1rem;
-  border-radius: 0.375rem;   /* mismo radio que Iniciar sesión */
+  border-radius: 0.375rem;
 }
 
 .back-btn-spacer {
-  width: 200px;   /* mismo ancho aprox que el botón de iniciar sesión */
+  width: 200px;
   height: 1px;
 }
+
+/* ===== Layout por columnas (Gerentes / Cotización / Reparación) ===== */
+.grilla-grupos {
+  display: grid;
+  gap: 28px;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 768px) { 
+  .grilla-grupos { 
+    grid-template-columns: repeat(2, 1fr); 
+  } 
+}
+@media (min-width: 1100px) { 
+  .grilla-grupos { 
+    grid-template-columns: repeat(3, 1fr); 
+  } 
+}
+
+/* Panel “Trabajadores” que ocupa 2 columnas en desktop */
+@media (min-width: 1100px) {
+  .trabajadores-col { 
+    grid-column: span 2; 
+  }
+}
+
+/* Subgrid interno para Cotización / Reparación */
+.subgrilla {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 768px) { 
+  .subgrilla { 
+    grid-template-columns: repeat(2, 1fr); 
+  } 
+}
+
+.subcol { 
+  background: transparent; 
+}
+
+/* Titulares */
+.grupo-title {
+  font-weight: 900;
+  text-align: center;
+  color: #fff;
+  font-size: clamp(1.4rem, 1.2rem + 1.2vw, 2.3rem);
+  padding: .65rem 1.2rem;
+  border-radius: 999px;
+  margin: 2px auto 14px;
+  width: min(92%, 520px);
+  background: linear-gradient(90deg, rgba(255,255,255,0.16), rgba(255,255,255,0.07));
+  border: 1px solid rgba(255,255,255,0.18);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.15);
+}
+
+.sub-title{
+  text-align:center;
+  color:#fff;
+  font-weight:800;
+  font-size: clamp(1.1rem, .95rem + .8vw, 1.6rem);
+  padding: .5rem 1rem;
+  border-radius: 999px;
+  background: rgba(255,255,255,.08);
+  border: 1px solid rgba(255,255,255,.18);
+  width: min(92%, 420px);
+  margin: 0.2rem auto 0.9rem;
+}
+
+/* Contenedor de tarjetas dentro de cada subcol */
+.grupo-cards { 
+  display:flex; 
+  flex-direction:column; 
+  gap:12px; 
+}
+
+.grupo-col {
+  border-radius: 20px;
+  padding: 16px 16px 18px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.08), rgba(255,255,255,0.03));
+  border: 1px solid rgba(255,255,255,0.18);
+  box-shadow:
+    0 10px 25px rgba(0,0,0,0.25),
+    inset 0 1px 0 rgba(255,255,255,0.15);
+  backdrop-filter: blur(6px);
+}
+
+.grupo-empty {
+  color: #ffffffcc;
+  text-align: center;
+  padding: 1rem .5rem;
+  border: 1px dashed rgba(255,255,255,0.25);
+  border-radius: 12px;
+  background: rgba(255,255,255,0.04);
+}
+
+/* Colores de los iconos de acción */
+.icon-btn.icon-edit { 
+  color:#16a34a; 
+}
+
+.icon-btn.icon-delete { 
+  color:#dc2626; 
+}
+
+.icon-btn.icon-edit:hover { 
+  background: rgba(22,163,74,.12); 
+}
+
+.icon-btn.icon-delete:hover { 
+  background: rgba(220,38,38,.12); 
+}
+
+
+
 


### PR DESCRIPTION
Esta vez me enfoqué en darle un mejor diseño al apartado de Administrar empleados. Ahora el listado se muestra separado por Gerentes y Trabajadores, y en cada tarjeta se ve claramente su sección (reparación o cotización) con un badge visual. También ajusté la flecha de regresar en esa misma interfaz para que sea más visible y coherente con el resto del estilo (tamaño, peso del ícono y estados hover/focus).
En Historial la flecha todavía está pendiente de ajustar; ahí aún no se refleja el nuevo diseño.