### PR TITLE
arreglo de flecha regresar y paleta de colores de administrar

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "axios": "^1.11.0",
         "bootstrap": "^5.3.8",
-        "framer-motion": "^12.23.12",
+        "framer-motion": "^12.23.16",
         "i18next": "^25.5.2",
-        "jspdf": "^3.0.2",
+        "jspdf": "^3.0.3",
         "lucide-react": "^0.541.0",
         "react": "^19.1.1",
         "react-datepicker": "^8.7.0",
@@ -2421,9 +2421,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.23.12",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
-      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "version": "12.23.16",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.16.tgz",
+      "integrity": "sha512-N81A8hiHqVsexOzI3wzkibyLURW1nEJsZaRuctPhG4AdbbciYu+bKJq9I2lQFzAO4Bx3h4swI6pBbF/Hu7f7BA==",
       "license": "MIT",
       "dependencies": {
         "motion-dom": "^12.23.12",
@@ -2800,9 +2800,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.2.tgz",
-      "integrity": "sha512-G0fQDJ5fAm6UW78HG6lNXyq09l0PrA1rpNY5i+ly17Zb1fMMFSmS+3lw4cnrAPGyouv2Y0ylujbY2Ieq3DSlKA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.3.tgz",
+      "integrity": "sha512-eURjAyz5iX1H8BOYAfzvdPfIKK53V7mCpBTe7Kb16PaM8JSXEcUQNBQaiWMI8wY5RvNOPj4GccMjTlfwRBd+oQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,9 @@
   "dependencies": {
     "axios": "^1.11.0",
     "bootstrap": "^5.3.8",
-    "framer-motion": "^12.23.12",
+    "framer-motion": "^12.23.16",
     "i18next": "^25.5.2",
-    "jspdf": "^3.0.2",
+    "jspdf": "^3.0.3",
     "lucide-react": "^0.541.0",
     "react": "^19.1.1",
     "react-datepicker": "^8.7.0",

--- a/frontend/src/pages/administrar_empleados.jsx
+++ b/frontend/src/pages/administrar_empleados.jsx
@@ -110,24 +110,27 @@ export default function AdministrarEmpleados() {
       >
         {/* HERO */}
         <div className="hero-section">
-          <div className="hero-row">
-            <button
-              className="btn_volver hero-back"
-              onClick={goBack}
-              aria-label="Regresar"
-              title="Regresar"
-            >
-              <ArrowLeft size={22} />
-            </button>
-            <div className="hero-copy text-center">
-              <h3 className="display-3 fw-bold mb-1">Administración de Empleados</h3>
-                <p className="lead opacity-75">
-                  Gestiona gerentes y trabajadores de manera rápida y sencilla.
-                </p>
-              </div>
+          <div className="hero-seccion">
+            <div className="hero-row">
+              <button
+                className="btn_volver hero-back"
+                onClick={goBack}
+                aria-label="Regresar"
+                title="Regresar"
+              >
+                <ArrowLeft size={22} />
+              </button>
+              <div className="hero-copy text-center">
+                <h3 className="display-3 fw-bold mb-1">Administración de Empleados</h3>
+                  <p className="lead opacity-75">
+                    Gestiona gerentes y trabajadores de manera rápida y sencilla.
+                  </p>
+                </div>
 
-          {/* Spacer derecho para mantener el centrado simétrico */}
-          <div aria-hidden="true" className="hero-right-spacer" />
+            {/* Spacer derecho para mantener el centrado simétrico */}
+            <div aria-hidden="true" className="hero-right-spacer" />
+            
+          </div>
         </div>
       </div>
 

--- a/frontend/src/pages/historial.jsx
+++ b/frontend/src/pages/historial.jsx
@@ -184,29 +184,39 @@ const Historial = () => {
   return (
     <AnimatePresence>
       <motion.div
-        className="full-width-container"
+        className="full-width-container historial-page"
         initial={{ opacity: 0, x: 50 }}
         animate={{ opacity: 1, x: 0 }}
         exit={{ opacity: 0, x: -50 }}
         transition={{ duration: 0.5 }}
       >
-        {/* HERO SECTION */}
+
+        {/* HERO */}
         <div className="hero-section">
-          <div className="d-flex align-items-center mt-2">
-            <button
-              className="btn_volver me-2"
-              onClick={goBack}
-              title="Regresar"
-              aria-label="Regresar"
-            >
-              <ArrowLeft size={20} />
-            </button>
-            <div className="text-center w-100">
-              <h3 className="display-3 fw-bold mb-1">Historial de Turnos</h3>
-              <p className="lead opacity-75">Consulta y filtra los turnos atendidos o pendientes.</p>
-            </div>
+          <div className="seccion-hero">
+            <div className="row-hero">
+              <button
+                className="btn_regresar hero-back"
+                onClick={goBack}
+                aria-label="Regresar"
+                title="Regresar"
+              >
+                <ArrowLeft size={22} />
+              </button>
+              <div className="hero-copy text-center">
+                <h3 className="display-3 fw-bold mb-1">Historial de Turnos</h3>
+                  <p className="lead opacity-75">
+                    Consulta y filtra los turnos atendidos o pendientes.
+                  </p>
+                </div>
+
+            {/* Spacer derecho para mantener el centrado simétrico */}
+            <div aria-hidden="true" className="hero-right-spacer" />
+            
           </div>
         </div>
+      </div>
+
 
         {/* CONTENIDO PRINCIPAL */}
         <div className="container px-3 px-md-5" style={{ marginTop: "-2rem", paddingBottom: "3rem" }}>

--- a/frontend/src/pages/pages-styles/administrar_empleados.css
+++ b/frontend/src/pages/pages-styles/administrar_empleados.css
@@ -1,11 +1,27 @@
-/* Contenedor principal */
+/* ===== Contenedor principal ===== */
 .administrar-page {
-  margin-top: 4rem;
+  margin-top: 0.2rem;
   padding-bottom: 3rem;
 }
 
-/* Header */
+/* ===== Paleta (solo colores) ===== */
+:root{
+  /* Rojos de marca */
+  --brand-red:       #E23B43;   /* principal */
+  --brand-red-dark:  #B3212B;   /* acento/gradiente */
+  --brand-red-85:    rgba(226,59,67,.90);
+  --brand-red-dark-85: rgba(179,33,43,.90);
 
+  /* Superficies claras */
+  --panel-white-1:   rgba(255,255,255,0.92);
+  --panel-white-2:   rgba(255,255,255,0.78);
+
+  /* Bordes/contrastes suaves */
+  --soft-border:     rgba(0,0,0,0.08);
+  --muted-white-bd:  rgba(255,255,255,0.18);
+}
+
+/* ===== Header ===== */
 .header {
   align-items: center;
   margin-bottom: 1.5rem;
@@ -20,51 +36,70 @@
   text-align: center;
 }
 
-/* El hero sirve de referencia para posicionar la flecha */
-.hero-section { padding: 34px 0 80px; }
+/* ===== Hero local (NO global) ===== */
+.hero-seccion { 
+  padding: 10px 0 0; 
+}
 
 /* Fila del hero: [flecha] [título centrado] [spacer] */
+:root{
+  --hero-btn-d: 44px;   /* diámetro del botón */
+  --hero-icon-d: 22px;  /* tamaño del ícono */
+}
+
 .hero-row{
   width: min(1100px, 92vw);
   margin: 0 auto;
   display: grid;
-  grid-template-columns: 44px 1fr 44px; /* flecha, contenido, espejo */
+  grid-template-columns: var(--hero-btn-d) 1fr var(--hero-btn-d);
   align-items: center;
   gap: 12px;
 }
 
-/* Botón circular estilo blanco,*/
+/* Botón circular blanco del hero */
 .btn_volver.hero-back{
-  position: static;
-  width: 44px; 
-  height: 44px;
+  width: var(--hero-btn-d);
+  height: var(--hero-btn-d);
+  border: 2px solid #fff;
   border-radius: 999px;
   background: transparent;
-  border: 2px solid #fff;
   color: #fff;
   display: flex; 
   align-items: center; 
   justify-content: center;
+  padding: 0;
+  line-height: 0;
   box-shadow: 0 2px 10px rgba(0,0,0,.25);
-  transition: background .2s, transform .1s;
+  transition: background .2s ease, transform .1s ease;
 }
-.btn_volver.hero-back:hover { background: rgba(255,255,255,.12); transform: translateY(-1px); }
-.btn_volver.hero-back svg { stroke: currentColor; }
+
+.btn_volver.hero-back:hover { 
+  background: rgba(255,255,255,.12); 
+  transform: translateY(-1px); 
+}
+
+.btn_volver.hero-back svg {
+  width: var(--hero-icon-d) !important; 
+  height: var(--hero-icon-d) !important;
+  stroke: currentColor;
+  flex: 0 0 auto;
+}
 
 /* Spacer del lado derecho del mismo tamaño que el botón */
-.hero-right-spacer{ width: 44px; height: 44px; }
+.hero-right-spacer{ 
+  width: var(--hero-btn-d); 
+  height: var(--hero-btn-d); 
+}
 
+/* Responsive: botón un poco más pequeño en móvil */
 @media (max-width: 420px){
-  .hero-row{ 
-    grid-template-columns: 40px 1fr 40px; 
-  }
-  .btn_volver.hero-back, .hero-right-spacer{ 
-    width: 40px; 
-    height: 40px; 
+  :root{
+    --hero-btn-d: 40px;
+    --hero-icon-d: 20px;
   }
 }
 
-/* Card de empleado */
+/* ===== Tarjetas de empleado ===== */
 .empleado-card {
   border-radius: 12px;
   transition: transform 0.2s, box-shadow 0.2s;
@@ -76,7 +111,7 @@
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
 }
 
-/* Botones de acción (editar / eliminar) */
+/* ===== Botones de acción (editar / eliminar) ===== */
 .icon-btn {
   border-radius: 50%;
   display: flex;
@@ -90,17 +125,17 @@
   background: #f0f0f0;
 }
 
-/* Botón agregar */
+/* ===== Botón agregar ===== */
 .add-btn {
   border-radius: 10px;
   padding: 0.65rem 1.5rem;
 }
 
-/* Contenedor: botón izquierda + título centrado + spacer derecha */
+/* ===== Contenedor: botón izquierda + título centrado + spacer derecha ===== */
 .header-with-back{
   display: flex;
   align-items: center;
-  justify-content: center;     /* centra el conjunto */
+  justify-content: center;
   gap: 12px;
   margin-bottom: 1rem;
 }
@@ -109,7 +144,7 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  padding: 0.375rem 0.75rem;  /* igual a Bootstrap btn */
+  padding: 0.375rem 0.75rem;
   font-size: 1rem;
   border-radius: 0.375rem;
 }
@@ -125,6 +160,7 @@
   gap: 28px;
   grid-template-columns: 1fr;
 }
+
 @media (min-width: 768px) { 
   .grilla-grupos { 
     grid-template-columns: repeat(2, 1fr); 
@@ -149,6 +185,7 @@
   gap: 18px;
   grid-template-columns: 1fr;
 }
+
 @media (min-width: 768px) { 
   .subgrilla { 
     grid-template-columns: repeat(2, 1fr); 
@@ -159,7 +196,7 @@
   background: transparent; 
 }
 
-/* Titulares */
+/* ===== Titulares ===== */
 .grupo-title {
   font-weight: 900;
   text-align: center;
@@ -169,9 +206,9 @@
   border-radius: 999px;
   margin: 2px auto 14px;
   width: min(92%, 520px);
-  background: linear-gradient(90deg, rgba(255,255,255,0.16), rgba(255,255,255,0.07));
-  border: 1px solid rgba(255,255,255,0.18);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.15);
+  background: linear-gradient(90deg, var(--brand-red-dark), var(--brand-red));
+  border: 1px solid var(--muted-white-bd);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.15);
 }
 
 .sub-title{
@@ -181,8 +218,8 @@
   font-size: clamp(1.1rem, .95rem + .8vw, 1.6rem);
   padding: .5rem 1rem;
   border-radius: 999px;
-  background: rgba(255,255,255,.08);
-  border: 1px solid rgba(255,255,255,.18);
+  background: linear-gradient(90deg, var(--brand-red-dark-85), var(--brand-red-85));
+  border: 1px solid var(--muted-white-bd);
   width: min(92%, 420px);
   margin: 0.2rem auto 0.9rem;
 }
@@ -197,24 +234,22 @@
 .grupo-col {
   border-radius: 20px;
   padding: 16px 16px 18px;
-  background: linear-gradient(180deg, rgba(255,255,255,0.08), rgba(255,255,255,0.03));
-  border: 1px solid rgba(255,255,255,0.18);
-  box-shadow:
-    0 10px 25px rgba(0,0,0,0.25),
-    inset 0 1px 0 rgba(255,255,255,0.15);
+  background: linear-gradient(180deg, var(--panel-white-1), var(--panel-white-2));
+  border: 1px solid var(--muted-white-bd);
+  box-shadow: 0 10px 25px rgba(0,0,0,0.25), inset 0 1px 0 rgba(255,255,255,0.15);
   backdrop-filter: blur(6px);
 }
 
 .grupo-empty {
-  color: #ffffffcc;
+  color: #333;
   text-align: center;
   padding: 1rem .5rem;
-  border: 1px dashed rgba(255,255,255,0.25);
+  border: 1px dashed var(--soft-border);
   border-radius: 12px;
-  background: rgba(255,255,255,0.04);
+  background: rgba(255,255,255,0.6);
 }
 
-/* Colores de los iconos de acción */
+/* ===== Colores de los iconos de acción ===== */
 .icon-btn.icon-edit { 
   color:#16a34a; 
 }
@@ -230,7 +265,3 @@
 .icon-btn.icon-delete:hover { 
   background: rgba(220,38,38,.12); 
 }
-
-
-
-

--- a/frontend/src/pages/pages-styles/historial.css
+++ b/frontend/src/pages/pages-styles/historial.css
@@ -1,3 +1,4 @@
+/* ===== Tooltip en tarjetas ===== */
 .tooltip-empleado {
   position: absolute;
   top: 1rem;
@@ -32,6 +33,7 @@
   transform: translateY(0);
 }
 
+/* ===== Encabezados secundarios ===== */
 .header {
   align-items: center;
   margin-bottom: 1.5rem;
@@ -46,16 +48,66 @@
   text-align: center;
 }
 
-.btn_volver {
-  background-color: #dc3545;
-  border: none;
-  color: white;
-  padding: 0.5rem 0.7rem;
-  display: flex;
+/* ===== Hero local (NO global) ===== */
+.seccion-hero { 
+  padding: 34px 0 80px; 
+}
+
+/* Tamaños unificados del botón del hero */
+:root{
+  --hero-btn-d: 44px;   /* diámetro del botón */
+  --hero-icon-d: 22px;  /* tamaño del ícono */
+}
+
+.row-hero{
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: var(--hero-btn-d) 1fr var(--hero-btn-d); /* [flecha][título][espejo] */
   align-items: center;
+  gap: 12px;
+}
+
+/* Botón circular blanco (posición estática dentro del grid) */
+.btn_regresar.hero-back{
+  width: var(--hero-btn-d);
+  height: var(--hero-btn-d);
+  border: 2px solid #fff;
+  border-radius: 999px;
+  background: transparent;
+  color: #fff;
+  display: flex; 
+  align-items: center; 
   justify-content: center;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-  width: 2.5rem;
-  margin-left: 2rem !important; /* Empuja el botón a la derecha */
+  padding: 0;
+  line-height: 0;
+  box-shadow: 0 2px 10px rgba(0,0,0,.25);
+  transition: background .2s ease, transform .1s ease;
+}
+
+.btn_regresar.hero-back:hover{
+  background: rgba(255,255,255,.12);
+  transform: translateY(-1px);
+}
+
+/* Asegura el tamaño del ícono */
+.btn_regresar.hero-back svg{ 
+  width: var(--hero-icon-d) !important;
+  height: var(--hero-icon-d) !important;
+  stroke: currentColor; 
+  flex: 0 0 auto;
+}
+
+/* Spacer derecho del mismo tamaño */
+.hero-right-spacer{
+  width: var(--hero-btn-d);
+  height: var(--hero-btn-d);
+}
+
+/* Responsive: un poco más pequeño en móvil */
+@media (max-width: 420px){
+  :root{
+    --hero-btn-d: 40px;
+    --hero-icon-d: 20px;
+  }
 }


### PR DESCRIPTION
En Administrar Empleados ya se distinguen mejor los apartados: primero los Gerentes y después los Trabajadores, que ahora se dividen en Cotización y Reparación con títulos destacados. Las tarjetas se muestran sobre un fondo blanco para que resalten más, y los botones de acción quedaron claros: verde para editar y rojo para eliminar.

También le metí mano a la flecha de regresar de historial, ajustando tamaño y estilo para que combine con el resto de la interfaz. En general, la paleta de colores quedó más uniforme entre secciones, así que tanto Administrar como Historial se ven más consistentes.