### PR TITLE
añadi contenedor para botones de historial,finalizar y administrar

### DIFF
--- a/frontend/src/pages/pages-styles/admin.css
+++ b/frontend/src/pages/pages-styles/admin.css
@@ -1,128 +1,138 @@
+/* ===== Hero ===== */
 .hero-section {
-    background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
-    color: white;
-    padding: 4rem 0;
-    margin-top: 56px; /* Altura de la navbar */
-    margin-bottom: auto;
-    position: relative;
-    width: 100%;
-    max-width: 100vw;
-    left: 0;
-    right: 0;
+  background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
+  color: white;
+  padding: 4rem 0;
+  margin-top: 56px; /* Altura de la navbar */
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  left: 0;
+  right: 0;
+  z-index: 0;
 }
-  
+
 .hero-section .text-center {
-    max-width: 1200px;         /* opcional: limita contenido centrado */
-    margin: 0 auto;
-    padding: 0 15px;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 15px;
 }
 
 .hero-section::after {
-    content: '';
-    position: absolute;
-    bottom: -40px;
-    left: 0;
-    width: 100%;
-    height: 100px;
-    background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
-    clip-path: ellipse(70% 100% at 50% 0%);
+  content: '';
+  position: absolute;
+  bottom: -40px;
+  left: 0;
+  width: 100%;
+  height: 100px;
+  background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
+  clip-path: ellipse(70% 100% at 50% 0%);
+  z-index: 0;
 }
 
+/* ===== Contenedor full ===== */
 .full-width-container {
-    width: 100vw;
-    padding: 0;
-    margin: 0;
-    overflow-x: hidden;
+  width: 100%;            /* evita el scroll horizontal de 100vw */
+  padding: 0;
+  margin: 0;
+  overflow-x: hidden;
 }
 
-.hero-section {
-    background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
-    color: white;
-    padding: 4rem 0;
-    margin-top: 56px; /* Altura de la navbar */
-    margin-bottom: auto;
-    position: relative;
-    width: 100%;
-    max-width: 100vw;
-    left: 0;
-    right: 0;
-}
-  
-.hero-section .text-center {
-    max-width: 1200px;         /* opcional: limita contenido centrado */
-    margin: 0 auto;
-    padding: 0 15px;
+/* El contenido va por encima de la “panza” del hero */
+.main-content {
+  position: relative;
+  z-index: 1;
+  margin-top: -3rem;
 }
 
-.hero-section::after {
-    content: '';
-    position: absolute;
-    bottom: -40px;
-    left: 0;
-    width: 100%;
-    height: 100px;
-    background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
-    clip-path: ellipse(70% 100% at 50% 0%);
+/* ===== Grid del listado ===== */
+.turnos-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
 }
 
-.full-width-container {
-    width: 100vw;
-    padding: 0;
-    margin: 0;
-    overflow-x: hidden;
+.turnos-grid {
+  grid-auto-rows: min-content !important;
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 1rem;
 }
 
-/* grupo de botones arriba, centrado */
-.acciones-header {
-  flex-wrap: wrap;
+/* Evitar que el .container global limite de más */
+.container {
+  max-width: 100%;
+  padding: 0 15px;
+  margin: 0 auto;
 }
 
-/* tamaño compacto consistente */
+/* ===== Panel de filtros / acciones (mismo look que Historial) ===== */
+.filtros-panel {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 16px;
+  box-shadow: 0 6px 20px rgba(0,0,0,.08);
+  padding: 16px 18px;
+}
+
+/* Grid responsivo de controles (input + 2 botones) */
+.filtros-grid {
+  display: grid;
+  grid-template-columns: 1fr repeat(2, minmax(140px, 1fr));
+  gap: 12px;
+  align-items: end;
+}
+@media (max-width: 992px) { .filtros-grid { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 576px) { .filtros-grid { grid-template-columns: 1fr; } }
+
+/* Label y campos */
+.filtro-label {
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 6px;
+}
+.filtro-input,
+.filtro-select {
+  border-radius: 10px;
+  height: 44px;
+}
+
+/* Botón rojo igual al “Limpiar” de Historial */
+.filtro-btn {
+  border: none;
+  border-radius: 10px;
+  height: 44px;
+  background: #dc3545;
+  color: #fff;
+  font-weight: 700;
+  padding: 0 .9rem;
+  transition: filter .15s ease;
+}
+.filtro-btn:hover { filter: brightness(0.92); }
+
+/* ===== Card “Turnos en Atención” translúcida ===== */
+:root{
+  --turnos-card-alpha: .88; /* sube/baja para más/menos transparencia */
+}
+.turnos-card{
+  background: rgba(255,255,255,var(--turnos-card-alpha)) !important;
+  border: 1px solid rgba(0,0,0,.06);
+  border-radius: 16px;
+  backdrop-filter: blur(4px);
+}
+
+/* ===== Botones compactos ===== */
 .btn-compacto {
-  display: inline-block !important;
-  min-width: 120px;   /* ancho fijo más corto */
-  max-width: 150px;   /* evita que se estiren de más */
-  padding: 6px 12px;  /* altura y ancho equilibrados */
+  display: inline-block;
+  min-width: 120px;
+  max-width: 150px;
+  padding: 6px 12px;
   font-size: 0.9rem;
   font-weight: 600;
   border-radius: 8px;
   text-align: center;
 }
 
-/* Contenedor: botón izquierda + título centrado + spacer derecha */
-.header-with-back{
-  display: flex;
-  align-items: center;
-  justify-content: center;     /* centra el conjunto */
-  gap: 12px;
-  margin-bottom: 1rem;
-}
-
-/* El spacer equilibra el ancho del botón para mantener el título centrado */
-.back-btn-spacer{
-  width: 38px;                 /* parecido al ancho del botón */
-  height: 1px;                 /* no visible */
-}
-
-/* Botón redondo sutil */
-.back-btn{
-  border-radius: 999px;
-  padding: 6px 10px;
-  box-shadow: 0 2px 4px rgba(0,0,0,.08);
-}
-
-/* Título grande centrado (opcional unifica estilos) */
-.titulo-seccion{
-  color: #fff;
-  font-weight: 800;
-  text-align: center;
-  text-shadow: 1px 1px 3px rgba(0,0,0,.35);
-  font-size: clamp(1.5rem, 4vw, 3rem);
-  margin: 0;
-}
-
-
-/* opcional: en pantallas chicas, que no se apachurren */
+/* Responsive */
 @media (max-width: 576px) {
   .btn-compacto { min-width: 120px; font-size: 0.9rem; }
 }

--- a/frontend/src/pages/pages-styles/superadmin.css
+++ b/frontend/src/pages/pages-styles/superadmin.css
@@ -1,39 +1,57 @@
-.hero-section {
-    background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
-    color: white;
-    padding: 4rem 0;
-    margin-top: 56px; /* Altura de la navbar */
-    margin-bottom: auto;
-    position: relative;
-    width: 100%;
-    max-width: 100vw;
-    left: 0;
-    right: 0;
+:root{
+  /* 1 = opaco, 0 = totalmente transparente */
+  --filtros-alpha: .85;
+  --turnos-card-alpha: .78;   /* ← mueve este valor para más/menos transparencia */
 }
-  
+
+/* ===== Hero ===== */
+.hero-section {
+  background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
+  color: white;
+  padding: 4rem 0;
+  margin-top: 56px;
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  left: 0;
+  right: 0;
+  z-index: 0;
+}
+
 .hero-section .text-center {
-    max-width: 1200px;         /* opcional: limita contenido centrado */
-    margin: 0 auto;
-    padding: 0 15px;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 15px;
 }
 
 .hero-section::after {
-    content: '';
-    position: absolute;
-    bottom: -40px;
-    left: 0;
-    width: 100%;
-    height: 100px;
-    background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
-    clip-path: ellipse(70% 100% at 50% 0%);
+  content: '';
+  position: absolute;
+  bottom: -40px;
+  left: 0;
+  width: 100%;
+  height: 100px;
+  background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
+  clip-path: ellipse(70% 100% at 50% 0%);
+  z-index: 0;
 }
 
+/* ===== Contenedor full ===== */
 .full-width-container {
-    width: 100vw;
-    padding: 0;
-    margin: 0;
-    overflow-x: hidden;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  overflow-x: hidden;
 }
+
+/* El contenido va por encima de la panza del hero */
+.main-content {
+  position: relative;
+  z-index: 1;
+  margin-top: -3rem; /* lo que tenías inline */
+}
+
+/* ===== Grid del listado ===== */
 .turnos-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -43,81 +61,89 @@
 .turnos-grid {
   grid-auto-rows: min-content !important;
   display: grid;
-  grid-template-columns: repeat(1, 1fr); /* columnas fijas */
+  grid-template-columns: repeat(1, 1fr);
   gap: 1rem;
 }
 
+/* Evitar que el .container global limite de más */
 .container {
-    max-width: 100vw; /* Asegura que el contenedor no exceda el ancho de la ventana */
-    padding: 0 15px; /* Espaciado horizontal */
-    margin: 0 auto; /* Centra el contenedor */
+  max-width: 100%;
+  padding: 0 15px;
+  margin: 0 auto;
 }
 
-.btn-custom {
-  margin: 0 8rem; /* espacio horizontal */
-  background-color: #d52e2e; 
+/* ===== Panel de filtros / acciones (mismo look que Historial) ===== */
+.filtros-panel {
+  background: rgba(255,255,255,var(--filtros-alpha));
+  border-radius: 16px;
+  box-shadow: 0 6px 20px rgba(0,0,0,.08);
+  padding: 16px 18px;
+}
+
+/* Grid responsivo de controles */
+.filtros-grid {
+  display: grid;
+  grid-template-columns: 1fr repeat(3, minmax(140px, 1fr)); /* input + 3 botones */
+  gap: 12px;
+  align-items: end;
+}
+@media (max-width: 992px) { .filtros-grid { grid-template-columns: 1fr 1fr 1fr; } }
+@media (max-width: 576px) { .filtros-grid { grid-template-columns: 1fr; } }
+
+/* Label y campos */
+.filtro-label {
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 6px;
+}
+.filtro-input,
+.filtro-select {
+  border-radius: 10px;
+  height: 44px;
+}
+
+/* Botón rojo igual al “Limpiar” de Historial */
+.filtro-btn {
   border: none;
-    color: white;
+  border-radius: 10px;
+  height: 44px;
+  background: #dc3545;
+  color: #fff;
+  font-weight: 700;
+  padding: 0 .9rem;
+  transition: filter .15s ease;
 }
+.filtro-btn:hover { filter: brightness(0.92); }
 
+/* ===== Extras opcionales que ya usabas ===== */
+.btn-custom {
+  margin: 0 8rem;
+  background-color: #d52e2e;
+  border: none;
+  color: white;
+}
 .btn-custom:hover {
   background-color: #e93838;
   color: white;
 }
 
-/* contenedor centrado y del tamaño justo del grupo */
-.acciones-centradas{
+.acciones-centradas {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 12px;              /* separación entre botones */
-  width: fit-content;     /* no ocupa todo el ancho */
+  gap: 12px;
+  width: fit-content;
 }
 
-/* tamaño compacto consistente (como tu maqueta) */
-.btn-compacto{
+.btn-compacto {
   display: inline-block;
-  min-width: 140px;       /* prueba 130–160 según veas */
+  min-width: 140px;
   padding: 8px 16px;
   font-weight: 700;
   border-radius: 10px;
   font-size: 0.95rem;
 }
 
-/* Contenedor: botón izquierda + título centrado + spacer derecha */
-.header-with-back{
-  display: flex;
-  align-items: center;
-  justify-content: center;     /* centra el conjunto */
-  gap: 12px;
-  margin-bottom: 1rem;
-}
-
-/* El spacer equilibra el ancho del botón para mantener el título centrado */
-.back-btn-spacer{
-  width: 38px;                 /* parecido al ancho del botón */
-  height: 1px;                 /* no visible */
-}
-
-/* Botón redondo sutil */
-.back-btn{
-  border-radius: 999px;
-  padding: 6px 10px;
-  box-shadow: 0 2px 4px rgba(0,0,0,.08);
-}
-
-/* Título grande centrado (opcional unifica estilos) */
-.titulo-seccion{
-  color: #fff;
-  font-weight: 800;
-  text-align: center;
-  text-shadow: 1px 1px 3px rgba(0,0,0,.35);
-  font-size: clamp(1.5rem, 4vw, 3rem);
-  margin: 0;
-}
-
-
-/* responsivo en pantallas chicas */
 @media (max-width: 576px){
   .btn-compacto{
     min-width: 120px;
@@ -125,4 +151,3 @@
     font-size: 0.9rem;
   }
 }
-

--- a/frontend/src/pages/vista_superadministrador.jsx
+++ b/frontend/src/pages/vista_superadministrador.jsx
@@ -1,20 +1,14 @@
 // src/pages/superadmin.jsx
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { Zap, ArrowLeft } from "../iconos";
-import { List, Grid } from "lucide-react";
-import WorkerTurnCard from "../components/WorkerTurnCard"; 
-import StatusBadge from "../components/StatusBadge";
+import { Zap } from "../iconos";
+import WorkerTurnCard from "../components/WorkerTurnCard";
 import { useDiaFinalizado } from "../hooks/useDiaFinalizado";
 import "./pages-styles/superadmin.css";
 
 const VistaSuperadministrador = () => {
   const navigate = useNavigate();
 
-  const [historial, setHistorial] = useState([]);
-  const [filtro, setFiltro] = useState("");
-  const [nombreEmpleado, setNombreEmpleado] = useState("");
-  const [vistaLista, setVistaLista] = useState(false);
   const [busqueda, setBusqueda] = useState("");
   const [showModal, setShowModal] = useState(false);
   const [diaFinalizado, setDiaFinalizado] = useDiaFinalizado();
@@ -23,39 +17,33 @@ const VistaSuperadministrador = () => {
     const empleado = JSON.parse(localStorage.getItem("empleado"));
     if (!empleado) {
       navigate("/login", { replace: true });
-    } else {
-      setNombreEmpleado(empleado.NOMBRE);
-      setFiltro(empleado.CARGO.toLowerCase());
-      //  Esto borra todo el historial anterior
-      window.history.pushState(null, "", window.location.href);
-      window.onpopstate = () => {
-        window.history.go(1); // Evita retroceder
-      };
+      return;
     }
+    // bloquear atrás
+    window.history.pushState(null, "", window.location.href);
+    window.onpopstate = () => window.history.go(1);
   }, [navigate]);
-
 
   const toggleDia = () => {
     if (diaFinalizado) {
-      // Iniciar nuevo día usando el mismo botón
       setDiaFinalizado(false);
       alert("Se inició un nuevo día. Ahora se pueden agendar turnos.");
     } else {
-      // Finalizar día
       setShowModal(true);
     }
   };
 
-  //función para finalizar el día
   const confirmarFinalizar = () => {
     setDiaFinalizado(true);
-    //setHistorial([]);
     setShowModal(false);
     alert("Día finalizado");
   };
 
+  const onFinalizarDia = toggleDia;
+
   return (
-    <div className="full-width-container">
+    <div className="full-width-container superadmin-page">
+      {/* HERO */}
       <div className="hero-section">
         <div className="container text-center">
           <h2 className="display-4 fw-bold mb-1">Administración</h2>
@@ -63,89 +51,79 @@ const VistaSuperadministrador = () => {
         </div>
       </div>
 
-      <div className="container" style={{ marginTop: "-3rem" }}>
-        <div className="row full-width-row g-4">
-          <div className="col-md-12 mb-4">
-            <div className="card shadow">
-              <div className="card-body d-flex justify-content-between align-items-center">
-                <h4 className="d-flex align-items-center card-title fw-bold text-dark mb-0">
-                  <Zap size={20} className="text-danger me-2" /> Turnos en Atención
+      {/* CONTENIDO */}
+      <div className="container main-content">
+        {/* Panel de filtros / acciones (estilo Historial) */}
+        <div className="filtros-panel mb-4">
+          <div className="filtros-grid">
+            {/* Buscar empleado */}
+            <div>
+              <label className="filtro-label">Buscar empleado</label>
+              <input
+                className="form-control filtro-input"
+                placeholder="Buscar empleado…"
+                value={busqueda}
+                onChange={(e) => setBusqueda(e.target.value)}
+              />
+            </div>
+
+            {/* Acciones */}
+            <button className="filtro-btn" onClick={onFinalizarDia}>
+              {diaFinalizado ? "Iniciar día" : "Finalizar día"}
+            </button>
+
+            <button className="filtro-btn" onClick={() => navigate("/historial")}>
+              Historial
+            </button>
+
+            <button className="filtro-btn" onClick={() => navigate("/administrar_empleados")}>
+              Administrar
+            </button>
+          </div>
+        </div>
+
+        {/* Card de Turnos */}
+        <div className="row g-4">
+          <div className="col-12 mb-4">
+            <div className="card shadow" style={{ backgroundColor: "rgba(255, 255, 255, 0.88)" }}>
+              <div className="card-body">
+                <h4 className="d-flex align-items-center card-title fw-bold text-dark mb-3">
+                  <Zap size={20} className="text-danger me-2" />
+                  Turnos en Atención
                 </h4>
 
-                {/* Contenedor buscador + botón */}
-                <div className="d-flex align-items-center gap-2">
-                  <input
-                    type="text"
-                    placeholder="Buscar empleado..."
-                    className="form-control form-control-sm"
-                    style={{ maxWidth: "200px" }}
-                    value={busqueda}
-                    onChange={(e) => setBusqueda(e.target.value)}
+                {/* Listado */}
+                <div className="turnos-grid" style={{ padding: "1rem" }}>
+                  <WorkerTurnCard
+                    filtroBusqueda={busqueda}
+                    mostrarCargo={true}
+                    modoLista={true}
                   />
-                  <button
-                    className="btn btn-outline-secondary btn-sm py-1 px-2"
-                    onClick={() => setVistaLista(!vistaLista)}
-                    title={vistaLista ? "Vista mosaico" : "Vista lista"}
-                  >
-                    {vistaLista ? <Grid size={14} /> : <List size={14} />}
-                  </button>
                 </div>
               </div>
-
-              {/* Botones centrados */}
-              <div className="acciones-centradas mx-auto mb-5">
-                <button
-                  className={`btn ${diaFinalizado ? "btn-success" : "btn-danger"} btn-compacto`}
-                  onClick={toggleDia}
-                >
-                  {diaFinalizado ? "Iniciar Nuevo Día" : "Finalizar día"}
-                </button>
-
-                <button
-                  className="btn btn-danger btn-compacto"
-                  onClick={() => navigate("/historial")}
-                >
-                  Historial
-                </button>
-
-                <button
-                  className="btn btn-danger btn-compacto"
-                  onClick={() => navigate("/administrar_empleados")}
-                >
-                  Administrar
-                </button>
-              </div>
-
-
-              {/* Contenedor dinámico */}
-              <div
-                className={vistaLista ? "turnos-list" : "turnos-grid"}
-                style={{ padding: "1rem" }}
-              >
-                <WorkerTurnCard 
-                  filtroBusqueda={busqueda}
-                  mostrarCargo={true}
-                  modoLista={true}   // 👈 esta prop
-                />
-
-              </div>
-
             </div>
           </div>
         </div>
-      </div>
+      </div> {/* /container main-content */}
 
-      {/* Modal de confirmación */}
+      {/* MODAL Finalizar día */}
       {showModal && !diaFinalizado && (
-        <div className="modal fade show d-block" style={{ backgroundColor: "rgba(0,0,0,0.5)" }}>
+        <div
+          className="modal fade show d-block"
+          style={{ backgroundColor: "rgba(0,0,0,0.5)" }}
+        >
           <div className="modal-dialog modal-dialog-centered">
             <div className="modal-content">
               <div className="modal-header">
                 <h5 className="modal-title">Confirmar acción</h5>
-                <button type="button" className="btn-close" onClick={() => setShowModal(false)} />
+                <button
+                  type="button"
+                  className="btn-close"
+                  onClick={() => setShowModal(false)}
+                />
               </div>
               <div className="modal-body">
-                <p>¿Seguro que deseas finalizar el día? </p>
+                <p>¿Seguro que deseas finalizar el día?</p>
               </div>
               <div className="modal-footer">
                 <button className="btn btn-secondary" onClick={() => setShowModal(false)}>
@@ -159,9 +137,8 @@ const VistaSuperadministrador = () => {
           </div>
         </div>
       )}
-    </div>
+    </div> /* /full-width-container */
   );
 };
-
 
 export default VistaSuperadministrador;


### PR DESCRIPTION
Lo que hice fue separar los botones de Finalizar día / Historial / Administrar del contenedor de “Turnos en Atención” y moverlos a un panel de acciones arriba, con el mismo estilo de filtros de Historial (pill, bordes redondeados, grid responsivo). Ahora “Turnos en Atención” es una card aparte con fondo blanco translúcido para mejorar la lectura. También dejé la visibilidad por rol: Gerente solo ve Historial y Administrar; Superadmin ve Finalizar día, Historial y Administrar. Son cambios solo de UI/estilos (sin tocar lógica ni endpoints). Para probar: entrar como gerente y superadmin y validar que el panel muestre los botones correctos y que el layout se mantenga responsivo.