### PR TITLE
creacion de papelera

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "axios": "^1.11.0",
         "bootstrap": "^5.3.8",
-        "framer-motion": "^12.23.16",
+        "framer-motion": "^12.23.18",
         "i18next": "^25.5.2",
         "jspdf": "^3.0.3",
         "lucide-react": "^0.541.0",
@@ -2421,12 +2421,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.23.16",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.16.tgz",
-      "integrity": "sha512-N81A8hiHqVsexOzI3wzkibyLURW1nEJsZaRuctPhG4AdbbciYu+bKJq9I2lQFzAO4Bx3h4swI6pBbF/Hu7f7BA==",
+      "version": "12.23.18",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.18.tgz",
+      "integrity": "sha512-HBVXBL5x3nk/0WrYM5G4VgjBey99ytVYET5AX17s/pcnlH90cyaxVUqgoN8cpF4+PqZRVOhwWsv28F+hxA9Tzg==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.23.12",
+        "motion-dom": "^12.23.18",
         "motion-utils": "^12.23.6",
         "tslib": "^2.4.0"
       },
@@ -2926,9 +2926,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.23.12",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
-      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "version": "12.23.18",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.18.tgz",
+      "integrity": "sha512-9piw3uOcP6DpS0qpnDF95bLDzmgMxLOg/jghLnHwYJ0YFizzuvbH/L8106dy39JNgHYmXFUTztoP9JQvUqlBwQ==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.23.6"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "axios": "^1.11.0",
     "bootstrap": "^5.3.8",
-    "framer-motion": "^12.23.16",
+    "framer-motion": "^12.23.18",
     "i18next": "^25.5.2",
     "jspdf": "^3.0.3",
     "lucide-react": "^0.541.0",

--- a/frontend/src/pages/administrar_empleados.jsx
+++ b/frontend/src/pages/administrar_empleados.jsx
@@ -9,19 +9,42 @@ import { useEmpleados } from "../layouts/EmpleadoContext";
 
 export default function AdministrarEmpleados() {
   const navigate = useNavigate();
+
+  // =========================
+  // Estados principales
+  // =========================
   const [empleados, setEmpleados] = useState([]);
+  const [openTrash, setOpenTrash] = useState(false);
+
+  const [trashData, setTrashData] = useState({
+    items: [],
+    page: 1,
+    totalPages: 1,
+    total: 0,
+  });
+
+  // Persistencia papelera
+  const TRASH_LS_KEY = "pitline_papelera_v1";
+  const TRASH_RETENTION_DAYS = 30;
+  const [trashHydrated, setTrashHydrated] = useState(false); // 👈 clave
+
+  // Tabs/paginación del drawer
+  const [trashTab, setTrashTab] = useState("empleados"); // 'empleados' | 'gerentes'
+  const [trashPage, setTrashPage] = useState(1);
+  const PAGE_SIZE = 5;
 
   // Contexto de empleados
   const { marcarAusente, quitarAusente, cargarAusentes } = useEmpleados();
 
-  // ---- Guardas / sesión ----
+  // =========================
+  // Guardas / sesión
+  // =========================
   useEffect(() => {
     const storedEmpleado = JSON.parse(localStorage.getItem("empleado"));
     if (!storedEmpleado) {
       navigate("/login", { replace: true });
       return;
     }
-
     const handlePopState = () => {
       window.history.pushState(null, "", window.location.href);
     };
@@ -45,7 +68,53 @@ export default function AdministrarEmpleados() {
     navigate(fallback, { replace: true });
   };
 
-  // ---- Cargar empleados ----
+  // =========================
+  // Hidratar papelera desde localStorage (y purgar antiguos)
+  // =========================
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(TRASH_LS_KEY);
+      if (!raw) {
+        setTrashHydrated(true);
+        return;
+      }
+      const parsed = JSON.parse(raw);
+      const now = Date.now();
+      const keep = Array.isArray(parsed?.items)
+        ? parsed.items.filter((it) => {
+            if (!it?.FECHA_ELIMINADO) return true;
+            const ageDays = (now - new Date(it.FECHA_ELIMINADO).getTime()) / 86400000;
+            return ageDays <= TRASH_RETENTION_DAYS;
+          })
+        : [];
+
+      setTrashData((s) => ({
+        ...s,
+        items: keep,
+        total: keep.length,
+        page: 1,
+      }));
+    } catch (e) {
+      console.error("Error leyendo papelera local:", e);
+    } finally {
+      // MUY IMPORTANTE: marcar hidratado para no pisar el storage con []
+      setTrashHydrated(true);
+    }
+  }, []);
+
+  // Guardar en localStorage cuando cambie, SOLO tras hidratar
+  useEffect(() => {
+    if (!trashHydrated) return;
+    try {
+      localStorage.setItem(TRASH_LS_KEY, JSON.stringify({ items: trashData.items }));
+    } catch (e) {
+      console.error("Error guardando papelera local:", e);
+    }
+  }, [trashData.items, trashHydrated]);
+
+  // =========================
+  // Cargar empleados y ausentes
+  // =========================
   useEffect(() => {
     fetch("http://127.0.0.1:8000/api/empleados")
       .then((res) => {
@@ -60,45 +129,139 @@ export default function AdministrarEmpleados() {
           cargo: (e.CARGO || "").toLowerCase(),
           tipo: e.ID_ROL === 0 ? "Administrador" : e.ID_ROL === 1 ? "Gerente" : "Empleado",
           ID_ROL: e.ID_ROL,
-          estado: typeof e.ESTADO !== "undefined" ? Number(e.ESTADO) : 1 // por defecto presente
+          estado: typeof e.ESTADO !== "undefined" ? Number(e.ESTADO) : 1,
         }));
         setEmpleados(empleadosNormalizados);
       })
       .catch(console.error);
   }, []);
 
-  // ---- Cargar ausentes al montar ----
   useEffect(() => {
     cargarAusentes();
   }, [cargarAusentes]);
 
+  // Bloquear scroll y cerrar con ESC cuando el drawer está abierto
+  useEffect(() => {
+    const onKey = (e) => e.key === "Escape" && setOpenTrash(false);
+    if (openTrash) {
+      document.body.style.overflowY = "hidden";
+      window.addEventListener("keydown", onKey);
+    }
+    return () => {
+      document.body.style.overflowY = "";
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [openTrash]);
 
-  // ---- Helpers ----
+  // =========================
+  // Helpers
+  // =========================
+  const capital = (s = "") => s.charAt(0).toUpperCase() + s.slice(1);
   const editar = (id) => navigate(`/editar_empleado/${id}`);
-  const eliminar = (id) => {
+
+  const eliminar = (emp) => {
     if (!window.confirm("¿Seguro que quieres eliminar este empleado?")) return;
-    fetch(`http://127.0.0.1:8000/api/empleados/${id}`, { method: "DELETE" })
+
+    fetch(`http://127.0.0.1:8000/api/empleados/${emp.id}`, { method: "DELETE" })
       .then((res) => {
         if (!res.ok) throw new Error("Error al eliminar");
-        setEmpleados((prev) => prev.filter((emp) => emp.id !== id));
+        // quitar de activos
+        setEmpleados((prev) => prev.filter((e) => e.id !== emp.id));
+        // push a papelera (evitar duplicados)
+        setTrashData((s) => {
+          const exists = s.items.some((i) => i.ID_EMPLEADO === emp.id);
+          const entry = {
+            ID_EMPLEADO: emp.id,
+            NOMBRE: emp.nombre,
+            CARGO: emp.cargo,    // "cotizacion" | "reparacion"
+            ID_ROL: emp.ID_ROL,  // 1=Gerente, 2=Empleado
+            FECHA_ELIMINADO: new Date().toISOString(),
+          };
+          const items = exists ? s.items : [entry, ...s.items];
+          return { ...s, items, total: items.length };
+        });
+
+        // UX: abrir papelera en la pestaña correcta y a la página 1
+        setOpenTrash(true);
+        setTrashTab(emp.ID_ROL === 1 ? "gerentes" : "empleados");
+        setTrashPage(1);
       })
       .catch(console.error);
   };
-  const capital = (s = "") => s.charAt(0).toUpperCase() + s.slice(1);
 
+  // Recuperar (intenta backend / fallback local)
+  const recuperar = async (id) => {
+    const item = trashData.items.find((i) => i.ID_EMPLEADO === id);
 
-  // ---- Optimistic update para ausentes/presentes ----
+    try {
+      // Si tu API no tiene restore (DELETE duro), esto fallará y caerá al fallback
+      const res = await fetch(`http://127.0.0.1:8000/api/empleados/${id}/restore`, {
+        method: "PUT",
+      });
+      if (!res.ok) throw new Error("restore-no-ok");
+
+      // Re-cargar empleados reales
+      const r2 = await fetch("http://127.0.0.1:8000/api/empleados");
+      if (!r2.ok) throw new Error("reload-no-ok");
+      const data = await r2.json();
+      const normalizados = data.map((e) => ({
+        id: e.ID_EMPLEADO,
+        ID_EMPLEADO: e.ID_EMPLEADO,
+        nombre: e.NOMBRE,
+        cargo: (e.CARGO || "").toLowerCase(),
+        tipo: e.ID_ROL === 0 ? "Administrador" : e.ID_ROL === 1 ? "Gerente" : "Empleado",
+        ID_ROL: e.ID_ROL,
+        estado: typeof e.ESTADO !== "undefined" ? Number(e.ESTADO) : 1,
+      }));
+      setEmpleados(normalizados);
+
+      // Quitar de papelera
+      setTrashData((s) => ({
+        ...s,
+        items: s.items.filter((i) => i.ID_EMPLEADO !== id),
+        total: Math.max(0, s.total - 1),
+      }));
+    } catch (err) {
+      // Fallback local: reinsertar en activos (no persiste en BD si tu DELETE es duro)
+      console.warn("Fallo restore en backend, usando restore local:", err);
+
+      if (item) {
+        setEmpleados((prev) => [
+          {
+            id: item.ID_EMPLEADO,
+            ID_EMPLEADO: item.ID_EMPLEADO,
+            nombre: item.NOMBRE,
+            cargo: (item.CARGO || "").toLowerCase(),
+            tipo: item.ID_ROL === 1 ? "Gerente" : "Empleado",
+            ID_ROL: item.ID_ROL,
+            estado: 1,
+          },
+          ...prev,
+        ]);
+
+        setTrashData((s) => ({
+          ...s,
+          items: s.items.filter((i) => i.ID_EMPLEADO !== id),
+          total: Math.max(0, s.total - 1),
+        }));
+      } else {
+        console.error("No se encontró el item en papelera para restaurar localmente");
+      }
+    }
+  };
+
+  // Toggle ausente/presente
   const toggleAusente = (emp) => {
-    // Actualización inmediata en UI
     setEmpleados((prev) =>
       prev.map((e) => (e.id === emp.id ? { ...e, estado: e.estado === 0 ? 1 : 0 } : e))
     );
-    // Llamada a backend
     if (emp.estado === 0) quitarAusente(emp.id).catch(console.error);
     else marcarAusente(emp.id).catch(console.error);
   };
 
-  // ---- Visibilidad por rol ----
+  // =========================
+  // Visibilidad y grupos
+  // =========================
   let visibles = [];
   if (isSuper) {
     visibles = empleados.filter((e) => e.tipo !== "Administrador");
@@ -108,17 +271,155 @@ export default function AdministrarEmpleados() {
     );
   }
 
-  // ---- Grupos ----
   const gerentes = isSuper ? visibles.filter((e) => e.tipo === "Gerente") : [];
   const cotizacion = visibles.filter((e) => e.tipo !== "Gerente" && e.cargo === "cotizacion");
   const reparacion = visibles.filter((e) => e.tipo !== "Gerente" && e.cargo === "reparacion");
 
-  // ---- Layout dinámico ----
-  const isGerente = role === "gerente";
   const gerenteCargo = storedEmpleado?.CARGO?.toLowerCase();
+  const isGerente = role === "gerente";
+  const gerenteArea = (storedEmpleado?.CARGO || "").toLowerCase();
 
+  // =========================
+  // Filtro + paginación de papelera
+  // =========================
+  const filteredTrash = trashData.items.filter((it) => {
+    if (isSuper) {
+      return trashTab === "empleados" ? it.ID_ROL === 2 : it.ID_ROL === 1;
+    }
+    return it.ID_ROL === 2 && (it.CARGO || "").toLowerCase() === gerenteArea;
+  });
+
+  const totalPagesTrash = Math.max(1, Math.ceil(filteredTrash.length / PAGE_SIZE));
+  const safePage = Math.min(trashPage, totalPagesTrash);
+  const start = (safePage - 1) * PAGE_SIZE;
+  const pagedTrash = filteredTrash.slice(start, start + PAGE_SIZE);
+
+  useEffect(() => {
+    setTrashPage((p) => Math.min(p, totalPagesTrash));
+  }, [filteredTrash.length, totalPagesTrash]);
+
+  const changeTrashTab = (tab) => {
+    if (trashTab === tab) return;
+    setTrashTab(tab);
+    setTrashPage(1);
+  };
+  const prevTrashPage = () => setTrashPage((p) => Math.max(1, p - 1));
+  const nextTrashPage = () => setTrashPage((p) => Math.min(totalPagesTrash, p + 1));
+
+  // =========================
+  // Render
+  // =========================
   return (
     <AnimatePresence>
+      {/* Drawer Papelera */}
+      <AnimatePresence>
+        {openTrash && (
+          <>
+            {/* Overlay */}
+            <motion.div
+              className="trash-overlay"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setOpenTrash(false)}
+            />
+            {/* Panel */}
+            <motion.aside
+              className="trash-drawer"
+              initial={{ x: "110%" }}
+              animate={{ x: 0 }}
+              exit={{ x: "110%" }}
+              transition={{ type: "tween", duration: 0.25 }}
+              role="dialog"
+              aria-modal="true"
+            >
+              <header className="trash-header">
+                <h3 className="trash-title">Papelera</h3>
+                <p className="trash-subtitle">
+                  {isSuper ? "Empleados y gerentes eliminados" : "Empleados eliminados de tu área"}
+                </p>
+                <button className="trash-close" onClick={() => setOpenTrash(false)} aria-label="Cerrar">
+                  ✕
+                </button>
+
+                {isSuper && (
+                  <div className="trash-tabs">
+                    <button
+                      className={`trash-tab ${trashTab === "empleados" ? "active" : ""}`}
+                      onClick={() => changeTrashTab("empleados")}
+                    >
+                      Empleados
+                    </button>
+                    <button
+                      className={`trash-tab ${trashTab === "gerentes" ? "active" : ""}`}
+                      onClick={() => changeTrashTab("gerentes")}
+                    >
+                      Gerentes
+                    </button>
+                  </div>
+                )}
+              </header>
+
+              <div className="trash-list">
+                {pagedTrash.length === 0 ? (
+                  <p className="trash-empty">No hay elementos eliminados.</p>
+                ) : (
+                  pagedTrash.map((it) => (
+                    <article key={it.ID_EMPLEADO} className="trash-item">
+                      <div className="trash-avatar">{(it.NOMBRE || "?").charAt(0)}</div>
+                      <div className="trash-info">
+                        <div className="trash-name">{it.NOMBRE}</div>
+                        <div className="trash-meta">
+                          <span className={`chip ${it.ID_ROL === 1 ? "chip--gerente" : "chip--empleado"}`}>
+                            {it.ID_ROL === 1 ? "Gerente" : "Empleado"}
+                          </span>
+                          {it.CARGO && <span className="chip chip--cargo">{it.CARGO}</span>}
+                          {it.FECHA_ELIMINADO && (
+                            <span className="chip chip--fecha">
+                              {new Date(it.FECHA_ELIMINADO).toLocaleDateString("es-MX", {
+                                day: "2-digit",
+                                month: "2-digit",
+                                year: "numeric",
+                              })}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <button
+                        className="trash-restore"
+                        onClick={() => recuperar(it.ID_EMPLEADO)}
+                        title="Recuperar"
+                      >
+                        ↺
+                      </button>
+                    </article>
+                  ))
+                )}
+              </div>
+
+              <footer className="trash-footer">
+                <div className="trash-page-info">
+                  Página {safePage} de {totalPagesTrash} • {filteredTrash.length} resultados
+                </div>
+                <div className="trash-pager">
+                  <button className="pager-btn" onClick={prevTrashPage} disabled={safePage <= 1}>
+                    ←
+                  </button>
+                  <button
+                    className="pager-btn"
+                    onClick={nextTrashPage}
+                    disabled={safePage >= totalPagesTrash}
+                  >
+                    →
+                  </button>
+                </div>
+              </footer>
+            </motion.aside>
+          </>
+        )}
+      </AnimatePresence>
+
+      {/* Página principal */}
       <motion.div
         className="full-width-container administrar-page"
         initial={{ opacity: 0, x: 50 }}
@@ -135,9 +436,7 @@ export default function AdministrarEmpleados() {
               </button>
               <div className="hero-copy text-center">
                 <h3 className="display-3 fw-bold mb-1">Administración de Empleados</h3>
-                <p className="lead opacity-75">
-                  Gestiona gerentes y trabajadores de manera rápida y sencilla.
-                </p>
+                <p className="lead opacity-75">Gestiona gerentes y trabajadores de manera rápida y sencilla.</p>
               </div>
               <div aria-hidden="true" className="hero-right-spacer" />
             </div>
@@ -152,139 +451,61 @@ export default function AdministrarEmpleados() {
             )}
           </div>
 
-            {/* Panel: para el superadmin*/}
-            {isSuper ? (
-              <div className="grilla-grupos">  
-                {/* seccion para gerentes */}
-                <section className="grupo-col">
-                  <h3 className="grupo-title">Gerentes</h3>
-                  <div className="grupo-cards">
-                    {gerentes.length === 0 && <p className="grupo-empty">Cargando...</p>}
-                    {gerentes.map((emp) => (
-                      <article className="card empleado-card" key={emp.id}>
-                        <div className="card-body d-flex justify-content-between align-items-center">
-                          <div>
-                            <div className="fw-bold">{emp.nombre}</div>
-                            <div className="text-muted small">{capital(emp.cargo)}</div>
-                          </div>
-                          <div className="d-flex gap-2">
-                            <button className="btn btn-light btn-sm" onClick={() => editar(emp.id)}>
-                              <Edit size={18} />
-                            </button>
-                            <button className="btn btn-light btn-sm" onClick={() => eliminar(emp.id)}>
-                              <Trash2 size={18} />
-                            </button>
-
-                            <button
-                              className={`btn btn-sm ${emp.estado === 1 ? "btn-warning" : "btn-success"}`}
-                              onClick={() => toggleAusente(emp)}
-                            >
-                              {emp.estado === 1 ? "Marcar ausente" : "Marcar presente"}
-                            </button>
-                          </div>
+          {/* Panel: para el superadmin */}
+          {isSuper ? (
+            <div className="grilla-grupos">
+              {/* Gerentes */}
+              <section className="grupo-col">
+                <h3 className="grupo-title">Gerentes</h3>
+                <div className="grupo-cards">
+                  {gerentes.length === 0 && <p className="grupo-empty">Cargando...</p>}
+                  {gerentes.map((emp) => (
+                    <article className="card empleado-card" key={emp.id}>
+                      <div className="card-body d-flex justify-content-between align-items-center">
+                        <div>
+                          <div className="fw-bold">{emp.nombre}</div>
+                          <div className="text-muted small">{capital(emp.cargo)}</div>
                         </div>
-                      </article>
-                    ))}
-                  </div>
-                </section>
-                {/* seccion para trabajadores */}
-                <section className="grupo-col trabajadores-col">
-                  {/* 👇 cambia el título según el rol */}
-                  <h3 className="grupo-title">
-                    {isSuper ? "Trabajadores" : `Área de ${capital(gerenteCargo)}`}
-                  </h3>
-                  <div className="subgrilla">
-                    <div className="subcol">
-                      <h4 className="sub-title">Cotización</h4>
-                      <div className="grupo-cards">
-                        {cotizacion.length === 0 && <p className="grupo-empty">Cargando...</p>}
-                        {cotizacion.map((emp) => (
-                          <article className="card empleado-card" key={emp.id}>
-                            <div className="card-body d-flex justify-content-between align-items-center">
-                              <div>
-                                <div className="fw-bold">{emp.nombre}</div>
-                                <div className="text-muted small">Empleado de Cotización</div>
-                              </div>
-                              <div className="d-flex gap-2">
-                                <button className="btn btn-light btn-sm" onClick={() => editar(emp.id)}>
-                                  <Edit size={18} />
-                                </button>
-                                <button className="btn btn-light btn-sm" onClick={() => eliminar(emp.id)}>
-                                  <Trash2 size={18} />
-                                </button>
-                                  <button
-                                    className={`btn btn-sm ${emp.estado === 1 ? "btn-warning" : "btn-success"}`}
-                                    onClick={() => toggleAusente(emp)}
-                                  >
-                                    {emp.estado === 1 ? "Marcar ausente" : "Marcar presente"}
-                                  </button>
-                              </div>
-                            </div>
-                          </article>
-                        ))}
+                        <div className="d-flex gap-2">
+                          <button className="btn btn-light btn-sm" onClick={() => editar(emp.id)}>
+                            <Edit size={18} />
+                          </button>
+                          <button className="btn btn-light btn-sm" onClick={() => eliminar(emp)}>
+                            <Trash2 size={18} />
+                          </button>
+                          <button
+                            className={`btn btn-sm ${emp.estado === 1 ? "btn-warning" : "btn-success"}`}
+                            onClick={() => toggleAusente(emp)}
+                          >
+                            {emp.estado === 1 ? "Marcar ausente" : "Marcar presente"}
+                          </button>
+                        </div>
                       </div>
-                    </div>
-                        
-                    <div className="subcol">
-                      <h4 className="sub-title">Reparación</h4>
-                      <div className="grupo-cards">
-                        {reparacion.length === 0 && <p className="grupo-empty">Cargando...</p>}
-                        {reparacion.map((emp) => (
-                          <article className="card empleado-card" key={emp.id}>
-                            <div className="card-body d-flex justify-content-between align-items-center">
-                              <div>
-                                <div className="fw-bold">{emp.nombre}</div>
-                                <div className="text-muted small">Empleado de Reparación</div>
-                              </div>
-                              <div className="d-flex gap-2">
-                                <button className="btn btn-light btn-sm" onClick={() => editar(emp.id)}>
-                                  <Edit size={18} />
-                                </button>
-                                <button className="btn btn-light btn-sm" onClick={() => eliminar(emp.id)}>
-                                  <Trash2 size={18} />
-                                </button>
-                                <button
-                                  className={`btn btn-sm ${emp.estado === 1 ? "btn-warning" : "btn-success"}`}
-                                  onClick={() => toggleAusente(emp)}
-                                >
-                                  {emp.estado === 1 ? "Marcar ausente" : "Marcar presente"}
-                                </button>
-                              </div>
-                            </div>
-                          </article>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                </section>
-              </div>  
-            ) : ( 
-              // Panel: para el gerente
-              <div className="grilla-grupos-para-gerente">
-                {/* seccion para trabajadores nadamas*/}
-                <section className="grupo-col trabajadores-col">
-                  {/* 👇 cambia el título según el rol */}
-                  <h3 className="grupo-title">
-                    {isSuper ? "Trabajadores" : `Área de ${capital(gerenteCargo)}`}
-                  </h3>
+                    </article>
+                  ))}
+                </div>
+              </section>
+
+              {/* Trabajadores */}
+              <section className="grupo-col trabajadores-col">
+                <h3 className="grupo-title">{isSuper ? "Trabajadores" : `Área de ${capital(gerenteCargo)}`}</h3>
+                <div className="subgrilla">
                   <div className="subcol">
-                    <h4 className="sub-title">{capital(gerenteCargo)}</h4>
+                    <h4 className="sub-title">Cotización</h4>
                     <div className="grupo-cards">
-                      {(gerenteCargo === "cotizacion" ? cotizacion : reparacion).length === 0 && (
-                        <p className="grupo-empty">Cargando...</p>
-                      )}
-                      {(gerenteCargo === "cotizacion" ? cotizacion : reparacion).map((emp) => (
+                      {cotizacion.length === 0 && <p className="grupo-empty">Cargando...</p>}
+                      {cotizacion.map((emp) => (
                         <article className="card empleado-card" key={emp.id}>
                           <div className="card-body d-flex justify-content-between align-items-center">
                             <div>
                               <div className="fw-bold">{emp.nombre}</div>
-                              <div className="text-muted small">Empleado de {capital(gerenteCargo)}</div>
+                              <div className="text-muted small">Empleado de Cotización</div>
                             </div>
                             <div className="d-flex gap-2">
                               <button className="btn btn-light btn-sm" onClick={() => editar(emp.id)}>
                                 <Edit size={18} />
                               </button>
-                              <button className="btn btn-light btn-sm" onClick={() => eliminar(emp.id)}>
+                              <button className="btn btn-light btn-sm" onClick={() => eliminar(emp)}>
                                 <Trash2 size={18} />
                               </button>
                               <button
@@ -299,13 +520,97 @@ export default function AdministrarEmpleados() {
                       ))}
                     </div>
                   </div>
-                </section>
-              </div>
-            )}
-          <div className="text-center mt-4">
+
+                  <div className="subcol">
+                    <h4 className="sub-title">Reparación</h4>
+                    <div className="grupo-cards">
+                      {reparacion.length === 0 && <p className="grupo-empty">Cargando...</p>}
+                      {reparacion.map((emp) => (
+                        <article className="card empleado-card" key={emp.id}>
+                          <div className="card-body d-flex justify-content-between align-items-center">
+                            <div>
+                              <div className="fw-bold">{emp.nombre}</div>
+                              <div className="text-muted small">Empleado de Reparación</div>
+                            </div>
+                            <div className="d-flex gap-2">
+                              <button className="btn btn-light btn-sm" onClick={() => editar(emp.id)}>
+                                <Edit size={18} />
+                              </button>
+                              <button className="btn btn-light btn-sm" onClick={() => eliminar(emp)}>
+                                <Trash2 size={18} />
+                              </button>
+                              <button
+                                className={`btn btn-sm ${emp.estado === 1 ? "btn-warning" : "btn-success"}`}
+                                onClick={() => toggleAusente(emp)}
+                              >
+                                {emp.estado === 1 ? "Marcar ausente" : "Marcar presente"}
+                              </button>
+                            </div>
+                          </div>
+                        </article>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </section>
+            </div>
+          ) : (
+            // Panel: para el gerente
+            <div className="grilla-grupos-para-gerente">
+              <section className="grupo-col trabajadores-col">
+                <h3 className="grupo-title">{isSuper ? "Trabajadores" : `Área de ${capital(gerenteCargo)}`}</h3>
+                <div className="subcol">
+                  <h4 className="sub-title">{capital(gerenteCargo)}</h4>
+                  <div className="grupo-cards">
+                    {(gerenteCargo === "cotizacion" ? cotizacion : reparacion).length === 0 && (
+                      <p className="grupo-empty">Cargando...</p>
+                    )}
+                    {(gerenteCargo === "cotizacion" ? cotizacion : reparacion).map((emp) => (
+                      <article className="card empleado-card" key={emp.id}>
+                        <div className="card-body d-flex justify-content-between align-items-center">
+                          <div>
+                            <div className="fw-bold">{emp.nombre}</div>
+                            <div className="text-muted small">Empleado de {capital(gerenteCargo)}</div>
+                          </div>
+                          <div className="d-flex gap-2">
+                            <button className="btn btn-light btn-sm" onClick={() => editar(emp.id)}>
+                              <Edit size={18} />
+                            </button>
+                            <button className="btn btn-light btn-sm" onClick={() => eliminar(emp)}>
+                              <Trash2 size={18} />
+                            </button>
+                            <button
+                              className={`btn btn-sm ${emp.estado === 1 ? "btn-warning" : "btn-success"}`}
+                              onClick={() => toggleAusente(emp)}
+                            >
+                              {emp.estado === 1 ? "Marcar ausente" : "Marcar presente"}
+                            </button>
+                          </div>
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                </div>
+              </section>
+            </div>
+          )}
+
+          <div className="acciones-footer">
             <Link to={registerPath} className="btn btn-danger fw-bold px-4 add-btn">
               Agregar Trabajador +
             </Link>
+            <button
+              type="button"
+              className="btn-trash"
+              title="Papelera"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setOpenTrash(true);
+              }}
+            >
+              🗑️ Papelera
+            </button>
           </div>
         </div>
       </motion.div>

--- a/frontend/src/pages/pages-styles/administrar_empleados.css
+++ b/frontend/src/pages/pages-styles/administrar_empleados.css
@@ -161,27 +161,15 @@
   grid-template-columns: 1fr;
 }
 
-.grilla-grupos-para-gerente {
-  display: grid;
-  gap: 28px;
-  grid-template-columns: 1fr;
-}
-
 @media (min-width: 768px) { 
   .grilla-grupos { 
     grid-template-columns: repeat(2, 1fr); 
   } 
-  .grilla-grupos-para-gerente { 
-    grid-template-columns: repeat(1, 1fr); 
-  }
 }
 @media (min-width: 1100px) { 
   .grilla-grupos { 
     grid-template-columns: repeat(3, 1fr); 
   } 
-  .grilla-grupos-para-gerente { 
-    grid-template-columns: repeat(1, 1fr); 
-  }
 }
 
 /* Panel “Trabajadores” que ocupa 2 columnas en desktop */
@@ -266,19 +254,202 @@
   background: rgba(255,255,255,0.6);
 }
 
-/* ===== Colores de los iconos de acción ===== */
-.icon-btn.icon-edit { 
-  color:#16a34a; 
+.acciones-footer{
+  display:flex;
+  gap:12px;
+  justify-content:center;
+  align-items:center;
+  flex-wrap:wrap;           /* por si en móvil no cabe, que baje a otra línea */
+  margin-top: clamp(24px, 7vh, 96px);
+  margin-bottom: 8px;
 }
 
-.icon-btn.icon-delete { 
-  color:#dc2626; 
+.btn-trash{
+  /* Asegura tamaño de botón, sin estirarse */
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:.5rem;
+  flex:0 0 auto;            /*lave: no crecer dentro del flex */
+  width:auto !important;    /* por si alguna regla global pone width:100% */
+  white-space:nowrap;
+  min-width:160px;
+  background:#f97316;
+  color:#fff;
+  font-weight:700;
+  border:0;
+  border-radius:12px;
+  padding:10px 16px;
+  box-shadow:0 8px 20px rgba(0,0,0,.18);
+  cursor:pointer;
+  transition:transform .15s ease, filter .15s ease;
+}
+.btn-trash:hover{
+  transform:translateY(-1px);
+  filter:brightness(1.05);
 }
 
-.icon-btn.icon-edit:hover { 
-  background: rgba(22,163,74,.12); 
+
+/* Overlay semitransparente */
+.trash-overlay{
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.4);
+  z-index: 999;
 }
 
-.icon-btn.icon-delete:hover { 
-  background: rgba(220,38,38,.12); 
+/* Drawer lateral separado de la orilla y del header */
+.trash-drawer{
+  position: fixed;
+  right: 16px;           /* separación del borde */
+  top: 64px;             /* baja para no chocar con el header */
+  width: min(380px, 92vw);
+  height: calc(100vh - 80px); /* deja margen sup/inf */
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.495);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
+
+/* Header del drawer */
+.trash-header{
+  padding: 16px 18px 8px;
+  background: linear-gradient(180deg, #ff7a18 0%, #ff3d54 100%);
+  color: #fff;
+  position: relative;
+}
+.trash-title{ font-size: 22px; font-weight: 800; margin: 0; }
+.trash-subtitle{ margin: 2px 0 0; opacity: .9; }
+.trash-close{
+  position: absolute; right: 10px; top: 10px;
+  background: transparent; border: 0; color: #fff; font-size: 22px; cursor: pointer;
+}
+
+/* Contenido */
+.trash-list{
+  padding: 12px 14px;
+  overflow-y: auto;
+  flex: 1;
+  background: #fff;
+}
+.trash-empty{
+  padding: 12px; text-align: center; color: #6b7280;
+}
+
+/* Footer de paginación */
+.trash-footer{
+  padding: 10px 14px;
+  background: #fff5ef;
+  border-top: 1px solid #ffe1d3;
+  display: flex; align-items: center; justify-content: space-between;
+}
+.trash-page-info{ font-size: 13px; color: #6b7280; }
+.trash-pager{ display: flex; gap: 8px; }
+.pager-btn{
+  width: 36px; height: 36px; border-radius: 999px; border: 1px solid #ffb791; background: #fff;
+  font-weight: 800; cursor: pointer;
+}
+.pager-btn:disabled{ opacity: .45; cursor: not-allowed; }
+
+/* Drawer ya existente… solo añadimos estilos de ítems bonitos */
+
+/* Ítem */
+.trash-item{
+  display: grid;
+  grid-template-columns: 40px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 12px;
+  padding: 12px 12px;
+  margin-bottom: 10px;
+  transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
+}
+.trash-item:hover{
+  border-color:#ffc8aa;
+  box-shadow: 0 6px 14px rgba(0,0,0,.06);
+  transform: translateY(-1px);
+}
+
+/* Avatar con la inicial */
+.trash-avatar{
+  width: 40px; height: 40px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  font-weight: 800; color:#fff;
+  background: linear-gradient(135deg,#ff7a18 0%, #ff3d54 100%);
+  box-shadow: 0 6px 12px rgba(255, 94, 94, .25);
+}
+
+/* Info */
+.trash-info{ min-width: 0; }
+.trash-name{
+  font-weight: 800;
+  line-height: 1.1;
+  color:#1f2937;
+}
+.trash-meta{
+  display:flex; flex-wrap:wrap;
+  gap:6px; margin-top:6px;
+}
+
+/* Chips */
+.chip{
+  font-size:12px; font-weight:700;
+  padding:4px 8px; border-radius:999px;
+  background:#fff0e8; border:1px solid #ffd9c7; color:#8a3a0d;
+  text-transform: capitalize;
+}
+.chip--gerente{ background:#eef6ff; border-color:#cfe3ff; color:#0b4aa6; }
+.chip--empleado{ background:#f1fff3; border-color:#c9f1cf; color:#126c2f; }
+.chip--fecha{ color:#6b7280; background:#f7f7f7; border-color:#e5e7eb; }
+
+.trash-tabs{
+  display:flex; gap:10px; margin:10px 0 0; flex-wrap:wrap;
+}
+.trash-tab{
+  border:0; cursor:pointer; font-weight:800; font-size:14px;
+  padding:8px 12px; border-radius:999px;
+  background:#fff6f0; color:#7a2e10; border:1px solid #ffd9c7;
+  transition:filter .15s ease, transform .15s ease;
+}
+.trash-tab:hover{ filter:brightness(1.03); transform:translateY(-1px); }
+.trash-tab.active{
+  background:#fff; color:#1f2937; border:2px solid #ffab87; box-shadow:0 4px 10px rgba(0,0,0,.06);
+}
+
+/* Botón restaurar */
+.trash-restore{
+  display:flex; align-items:center; justify-content:center;
+  gap:6px; padding:8px 10px;
+  background:#10b981; color:#fff;
+  border:0; border-radius:10px; font-weight:800;
+  box-shadow: 0 4px 12px rgba(16,185,129,.28);
+  cursor:pointer; transition: filter .15s ease, transform .15s ease;
+}
+.trash-restore:hover{ filter:brightness(1.05); transform: translateY(-1px); }
+.i-restore{ font-size:16px; line-height: 1; }
+.sr-only{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
+
+/* Scrollbar del drawer (opcional, bonito) */
+.trash-list::-webkit-scrollbar{ width:10px; }
+.trash-list::-webkit-scrollbar-thumb{
+  background:#ffd9c7; border-radius:999px; border:3px solid #fff;
+}
+.trash-list{ scrollbar-width:thin; scrollbar-color:#ffd9c7 #fff; }
+
+
+/* Responsive */
+@media (max-width: 768px){
+  .trash-drawer{
+    right: 8px; left: 8px; width: auto;
+    top: 56px;
+    height: calc(100vh - 72px);
+  }
+}
+
+

--- a/frontend/src/pages/pages-styles/superadmin.css
+++ b/frontend/src/pages/pages-styles/superadmin.css
@@ -1,9 +1,3 @@
-:root{
-  /* 1 = opaco, 0 = totalmente transparente */
-  --filtros-alpha: .85;
-  --turnos-card-alpha: .78;   /* ← mueve este valor para más/menos transparencia */
-}
-
 /* ===== Hero ===== */
 .hero-section {
   background: linear-gradient(90deg, #dc3545 0%, #c82333 100%);
@@ -74,7 +68,7 @@
 
 /* ===== Panel de filtros / acciones (mismo look que Historial) ===== */
 .filtros-panel {
-  background: rgba(255,255,255,var(--filtros-alpha));
+  background: rgba(255, 255, 255, 0.85);
   border-radius: 16px;
   box-shadow: 0 6px 20px rgba(0,0,0,.08);
   padding: 16px 18px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "crud_con_roles",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "react-icons": "^5.5.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react-icons": "^5.5.0"
+  }
+}


### PR DESCRIPTION
Implementé la Papelera en “Administrar Empleados” como un drawer lateral con overlay, sin saltos de scroll al abrir o cerrar y con cierre por clic fuera o tecla Esc. El botón de papelera quedó acomodado junto a “Agregar trabajador” sin estirarse ni romper el layout. Dentro del drawer se muestran tarjetas con avatar inicial, chips de rol/área/fecha y un botón de restaurar.

La lista de eliminados tiene paginación fija de 5 por página y respeta el contexto del usuario: si es superadmin puede alternar entre Empleados y Gerentes; si es gerente solo ve empleados de su área (cotización o reparación). La eliminación es optimista (se quita del listado y se añade a la papelera al instante) y la restauración intenta primero el endpoint (PUT /api/empleados/:id/restore); si el backend no soporta restore porque el delete es duro, se hace un fallback local para no bloquear al usuario. La papelera persiste en localStorage bajo la clave pitline_papelera_v1 con purga automática a 30 días, y se agregó una hidratación inicial para evitar que React en modo estricto la sobrescriba al montar.