### PR TITLE
creacion del apartado papelera

### DIFF
--- a/frontend/src/pages/pages-styles/administrar_empleados.css
+++ b/frontend/src/pages/pages-styles/administrar_empleados.css
@@ -354,8 +354,6 @@
 }
 .pager-btn:disabled{ opacity: .45; cursor: not-allowed; }
 
-/* Drawer ya existente… solo añadimos estilos de ítems bonitos */
-
 /* Ítem */
 .trash-item{
   display: grid;


### PR DESCRIPTION
Implementé la Papelera en “Administrar Empleados” como un drawer lateral con overlay, sin saltos de scroll al abrir o cerrar y con cierre por clic fuera o tecla Esc. El botón de papelera quedó acomodado junto a “Agregar trabajador” sin estirarse ni romper el layout. Dentro del drawer se muestran tarjetas con avatar inicial, chips de rol/área/fecha y un botón de restaurar.

La lista de eliminados tiene paginación fija de 5 por página y respeta el contexto del usuario: si es superadmin puede alternar entre Empleados y Gerentes; si es gerente solo ve empleados de su área (cotización o reparación). La eliminación es optimista (se quita del listado y se añade a la papelera al instante) y la restauración intenta primero el endpoint (PUT /api/empleados/:id/restore); si el backend no soporta restore porque el delete es duro, se hace un fallback local para no bloquear al usuario. La papelera persiste en localStorage bajo la clave pitline_papelera_v1 con purga automática a 30 días, y se agregó una hidratación inicial para evitar que React en modo estricto la sobrescriba al montar.